### PR TITLE
町字エンドポイントの丁目が算用数字の場合に漢数字に置換

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@geolonia/japanese-numeral": "^1.0.2",
         "@tsconfig/node22": "^22.0.0",
         "@types/better-sqlite3": "^7.6.12",
         "@types/cli-progress": "^3.11.6",
@@ -671,6 +672,16 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@geolonia/japanese-numeral": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@geolonia/japanese-numeral/-/japanese-numeral-1.0.2.tgz",
+      "integrity": "sha512-fOgkPtiewCpdMtQRqbfbR1ebkv4yxNoic0e90GYCdDzScUjrwc3AezpbGuw0sPUJE8HcT2TLZYdp7qpI7TQwHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@geolonia/japanese-numeral": "^1.0.2",
     "@tsconfig/node22": "^22.0.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/cli-progress": "^3.11.6",

--- a/src/processes/02_machi_aza.test.ts
+++ b/src/processes/02_machi_aza.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import { rawToMachiAza } from './02_machi_aza.js';
+import { MachiAzaData } from '../lib/ckan_data/machi_aza.js';
+
+const raw: MachiAzaData = {
+  lg_code: '131041',
+  machiaza_id: '0020003',
+  machiaza_type: '2',
+  pref: '東京都',
+  pref_kana: 'トウキョウト',
+  pref_roma: 'Tokyo',
+  county: '',
+  county_kana: '',
+  county_roma: '',
+  city: '新宿区',
+  city_kana: 'シンジュクク',
+  city_roma: 'Shinjuku-ku',
+  ward: '',
+  ward_kana: '',
+  ward_roma: '',
+  oaza_cho: '新宿',
+  oaza_cho_kana: 'シンジュク',
+  oaza_cho_roma: 'Shinjuku',
+  chome: '３丁目',
+  chome_kana: '３チョウメ',
+  chome_number: '3',
+  koaza: '',
+  koaza_kana: '',
+  koaza_roma: '',
+  machiaza_dist: '',
+  rsdt_addr_flg: '1',
+  rsdt_addr_mtd_code: '1',
+  oaza_cho_aka_flg: '0',
+  koaza_aka_code: '0',
+  oaza_cho_gsi_uncmn: '0',
+  koaza_gsi_uncmn: '0',
+  status_flg: '1',
+  wake_num_flg: '1',
+  efct_date: '1947-04-17',
+  ablt_date: '',
+  src_code: '0',
+  post_code: '',
+  remarks: '',
+};
+
+await test('rawToMachiAza converts 全角算用(アラビア)数字 丁目 with 漢数字', () => {
+  const result = rawToMachiAza({ ...raw, chome: '３丁目' });
+  assert.strictEqual(result.chome, '三丁目');
+
+  const result2 = rawToMachiAza({ ...raw, chome: '１０丁目' });
+  assert.strictEqual(result2.chome, '十丁目');
+
+  const result3 = rawToMachiAza({ ...raw, chome: '２０丁目' });
+  assert.strictEqual(result3.chome, '二十丁目');
+
+  const result4 = rawToMachiAza({ ...raw, chome: '４９丁目' });
+  assert.strictEqual(result4.chome, '四十九丁目');
+});
+
+await test('rawToMachiAza converts 全角算用(アラビア)数字 丁 with 漢数字', () => {
+  const result = rawToMachiAza({ ...raw, chome: '３丁' });
+  assert.strictEqual(result.chome, '三丁');
+
+  const result2 = rawToMachiAza({ ...raw, chome: '１０丁' });
+  assert.strictEqual(result2.chome, '十丁');
+
+  const result3 = rawToMachiAza({ ...raw, chome: '２０丁' });
+  assert.strictEqual(result3.chome, '二十丁');
+
+  const result4 = rawToMachiAza({ ...raw, chome: '４９丁' });
+  assert.strictEqual(result4.chome, '四十九丁');
+});
+
+await test('rawToMachiAza converts 半角算用(アラビア)数字 丁目 with 漢数字', () => {
+  const result = rawToMachiAza({ ...raw, chome: '3丁目' });
+  assert.strictEqual(result.chome, '三丁目');
+
+  const result2 = rawToMachiAza({ ...raw, chome: '10丁目' });
+  assert.strictEqual(result2.chome, '十丁目');
+
+  const result3 = rawToMachiAza({ ...raw, chome: '20丁目' });
+  assert.strictEqual(result3.chome, '二十丁目');
+
+  const result4 = rawToMachiAza({ ...raw, chome: '49丁目' });
+  assert.strictEqual(result4.chome, '四十九丁目');
+});
+
+await test('rawToMachiAza converts 半角算用(アラビア)数字 丁 with 漢数字', () => {
+  const result = rawToMachiAza({ ...raw, chome: '3丁' });
+  assert.strictEqual(result.chome, '三丁');
+
+  const result2 = rawToMachiAza({ ...raw, chome: '10丁' });
+  assert.strictEqual(result2.chome, '十丁');
+
+  const result3 = rawToMachiAza({ ...raw, chome: '20丁' });
+  assert.strictEqual(result3.chome, '二十丁');
+
+  const result4 = rawToMachiAza({ ...raw, chome: '49丁' });
+  assert.strictEqual(result4.chome, '四十九丁');
+});
+
+await test('rawToMachiAza keeps 漢数字 丁目 as it is', () => {
+  const result = rawToMachiAza({ ...raw, chome: '三丁目' });
+  assert.strictEqual(result.chome, '三丁目');
+
+  const result2 = rawToMachiAza({ ...raw, chome: '十丁目' });
+  assert.strictEqual(result2.chome, '十丁目');
+
+  const result3 = rawToMachiAza({ ...raw, chome: '二十丁目' });
+  assert.strictEqual(result3.chome, '二十丁目');
+
+  const result4 = rawToMachiAza({ ...raw, chome: '四十九丁目' });
+  assert.strictEqual(result4.chome, '四十九丁目');
+});
+
+await test('rawToMachiAza keeps 漢数字 丁 as it is', () => {
+  const result = rawToMachiAza({ ...raw, chome: '三丁' });
+  assert.strictEqual(result.chome, '三丁');
+
+  const result2 = rawToMachiAza({ ...raw, chome: '十丁' });
+  assert.strictEqual(result2.chome, '十丁');
+
+  const result3 = rawToMachiAza({ ...raw, chome: '二十丁' });
+  assert.strictEqual(result3.chome, '二十丁');
+
+  const result4 = rawToMachiAza({ ...raw, chome: '四十九丁' });
+  assert.strictEqual(result4.chome, '四十九丁');
+});

--- a/src/processes/02_machi_aza.ts
+++ b/src/processes/02_machi_aza.ts
@@ -1,8 +1,20 @@
+import { kanji2number, number2kanji } from '@geolonia/japanese-numeral'
 import { SingleMachiAza } from "../data.js";
 import { MachiAzaData, MachiAzaPosData } from "../lib/ckan_data/machi_aza.js";
 import { projectABRData } from "../lib/proj.js";
 
 export function rawToMachiAza(raw: MachiAzaData | (MachiAzaData & MachiAzaPosData)): SingleMachiAza {
+  let kanjiChome = undefined;
+  if (raw.chome !== '') {
+    const numberChomePattern = /([０-９]+)(丁目?)/;
+    const matches = raw.chome.match(numberChomePattern);
+    if (!matches) {
+      kanjiChome = raw.chome;
+    } else if (matches.length === 3) {
+      const number = kanji2number(matches[1]);
+      kanjiChome = number2kanji(number) + matches[2];
+    }
+  }
   return {
     machiaza_id: raw.machiaza_id,
 
@@ -10,7 +22,7 @@ export function rawToMachiAza(raw: MachiAzaData | (MachiAzaData & MachiAzaPosDat
     oaza_cho_k: raw.oaza_cho_kana === '' ? undefined : raw.oaza_cho_kana,
     oaza_cho_r: raw.oaza_cho_roma === '' ? undefined : raw.oaza_cho_roma,
 
-    chome: raw.chome === '' ? undefined : raw.chome,
+    chome: kanjiChome,
     chome_n: raw.chome_number === '' ? undefined : parseInt(raw.chome_number, 10),
 
     koaza: raw.koaza === '' ? undefined : raw.koaza,

--- a/src/processes/02_machi_aza.ts
+++ b/src/processes/02_machi_aza.ts
@@ -6,7 +6,7 @@ import { projectABRData } from "../lib/proj.js";
 export function rawToMachiAza(raw: MachiAzaData | (MachiAzaData & MachiAzaPosData)): SingleMachiAza {
   let kanjiChome = undefined;
   if (raw.chome !== '') {
-    const numberChomePattern = /([０-９]+)(丁目?)/;
+    const numberChomePattern = /([０-９0-9]+)(丁目?)/;
     const matches = raw.chome.match(numberChomePattern);
     if (!matches) {
       kanjiChome = raw.chome;

--- a/src/processes/04_make_chiban.ts
+++ b/src/processes/04_make_chiban.ts
@@ -9,6 +9,7 @@ import { ckanPackageSearch, findResultByTypeAndArea, getAndParseCSVDataForId, ge
 import { machiAzaName, SingleChiban, SingleMachiAza } from '../data.js';
 import { projectABRData } from '../lib/proj.js';
 import { MachiAzaData } from '../lib/ckan_data/machi_aza.js';
+import { rawToMachiAza } from './02_machi_aza.js';
 import { ChibanData, ChibanPosData } from '../lib/ckan_data/chiban.js';
 import { mergeDataLeftJoin } from '../lib/ckan_data/index.js';
 
@@ -164,7 +165,7 @@ async function main(argv: string[]) {
         }
         if (currentMachiAza && (currentMachiAza.machiaza_id !== ma.machiaza_id || currentMachiAza.lg_code !== ma.lg_code)) {
           apiData.push({
-            machiAza: currentMachiAza,
+            machiAza: rawToMachiAza(currentMachiAza),
             chibans: currentChibanList,
           });
           currentChibanList = [];
@@ -183,7 +184,7 @@ async function main(argv: string[]) {
       }
       if (currentMachiAza && currentChibanList.length > 0) {
         apiData.push({
-          machiAza: currentMachiAza,
+          machiAza: rawToMachiAza(currentMachiAza),
           chibans: currentChibanList,
         });
       }


### PR DESCRIPTION
#11 に対する修正となります。

2025/06/26時点のデジタル庁のアドレス・ベース・レジストリの町字マスターの `chome` 列の値は、以下のように漢数字と算用数字が混ざる形となっていたため、丁(目)の前が算用数字の場合のみ、漢数字に置き換える処理を行いました。

お手すきの際に確認頂けますと幸いです。🙇

<details>
<summary>2025/06/26時点の町字マスター chome列全パターン</summary>

```csv
chome
一丁
一丁目
七丁目
三丁
三丁目
九丁目
二丁
二丁目
二十一丁目
二十丁目
二十二丁目
五丁目
八丁目
六丁目
十一丁目
十丁目
十七丁目
十三丁目
十九丁目
十二丁目
十五丁目
十八丁目
十六丁目
十四丁目
四丁
四丁目
１丁
１丁目
１０丁
１０丁目
１１丁目
１２丁目
１３丁目
１４丁目
１５丁目
１６丁目
１７丁目
１８丁目
１９丁目
２丁
２丁目
２０丁目
２１丁目
２２丁目
２３丁目
２４丁目
２５丁目
２６丁目
２７丁目
２８丁目
２９丁目
３丁
３丁目
３０丁目
３１丁目
３２丁目
３３丁目
３４丁目
３５丁目
３６丁目
３７丁目
３８丁目
３９丁目
４丁
４丁目
４０丁目
４１丁目
４２丁目
５丁
５丁目
６丁
６丁目
７丁
７丁目
８丁
８丁目
９丁
９丁目
```

</details>

<details>
<summary>(参考) 2024/04/18時点の町字マスター chome列全パターン</summary>

```csv
chome
一丁
一丁目
七丁
七丁目
三丁
三丁目
三十一丁目
三十丁目
三十七丁目
三十三丁目
三十九丁目
三十二丁目
三十五丁目
三十八丁目
三十六丁目
三十四丁目
九丁
九丁目
二丁
二丁目
二十一丁目
二十丁目
二十七丁目
二十三丁目
二十九丁目
二十二丁目
二十五丁目
二十八丁目
二十六丁目
二十四丁目
五丁
五丁目
八丁
八丁目
六丁
六丁目
十一丁目
十丁
十丁目
十七丁目
十三丁目
十九丁目
十二丁目
十五丁目
十八丁目
十六丁目
十四丁目
四丁
四丁目
四十一丁目
四十丁目
四十二丁目
```

</details>

<details>
<summary>(補足) duckdbでの上記パターン出力メモ</summary>

```sh
brew install duckdb
duckdb
```
```sql
-- mt_town_all.csv の読み込み
CREATE OR REPLACE TABLE mt_town_all AS
  SELECT * FROM read_csv_auto(
    'mt_town_all.csv',
    delim=',',
    header=True
  );

-- chome列の重複を除去してCSVにエクスポート
COPY (
  SELECT DISTINCT(chome) AS chome
    FROM mt_town_all
    ORDER BY chome
) TO 'chome.csv' (HEADER, DELIMITER ',');
```

</details>

---

Closes #11