### PR TITLE
町字エンドポイントJSONの住居表示フラグに、町字位置参照情報マスターでなく町字マスターの値を利用するよう修正

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -110,7 +110,7 @@ export type SingleMachiAza = {
   koaza_r?: string;
 
   /** 住居表示住所の情報の存在。値が存在しない場合は、住居表示住所の情報は存在しません。 */
-  rsdt?: true;
+  rsdt?: boolean;
 
   /** 代表点 */
   point?: LngLat;

--- a/src/lib/ckan_data/machi_aza.ts
+++ b/src/lib/ckan_data/machi_aza.ts
@@ -115,3 +115,16 @@ export type MachiAzaPosData = {
   /// 国勢調査_境界_データ整備年度
   cns_bnd_year: string;
 };
+
+export type MachiAzaMinPosData = {
+  /// 全国地方公共団体コード
+  lg_code: string;
+  /// 町字ID
+  machiaza_id: string;
+  /// 代表点_経度
+  rep_lon: string;
+  /// 代表点_緯度
+  rep_lat: string;
+  /// 代表点_座標参照系
+  rep_srid: string;
+};

--- a/src/processes/02_make_machi_aza.ts
+++ b/src/processes/02_make_machi_aza.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { getAndStreamCSVDataForId } from '../lib/ckan.js';
 import { MachiAzaApi, SingleMachiAza } from '../data.js';
-import { MachiAzaData, MachiAzaPosData } from '../lib/ckan_data/machi_aza.js';
+import { MachiAzaData, MachiAzaPosData, MachiAzaMinPosData } from '../lib/ckan_data/machi_aza.js';
 import { mergeDataLeftJoin } from '../lib/ckan_data/index.js';
 import { rawToMachiAza } from './02_machi_aza.js';
 import { downloadAndExtractNlftpMlitFile, NlftpMlitDataRow } from '../lib/mlit_nlftp.js';
@@ -30,7 +30,18 @@ async function main(argv: string[]) {
 
   const mainStream = getAndStreamCSVDataForId<MachiAzaData>('ba-o1-000000_g2-000003');
   const posStream = getAndStreamCSVDataForId<MachiAzaPosData>('ba000004');
-  const rawData = mergeDataLeftJoin(mainStream, posStream, ['lg_code', 'machiaza_id']);
+  const minPosStream = async function* minPosStream(posStream: AsyncIterable<MachiAzaMinPosData>) {
+    for await (const pos of posStream) {
+      yield {
+        lg_code: pos.lg_code,
+        machiaza_id: pos.machiaza_id,
+        rep_lon: pos.rep_lon,
+        rep_lat: pos.rep_lat,
+        rep_srid: pos.rep_srid,
+      };
+    }
+  }
+  const rawData = mergeDataLeftJoin(mainStream, minPosStream(posStream), ['lg_code', 'machiaza_id']);
   // const rawData = mergeMachiAzaData(mainStream, posStream);
 
   let lastLGCode: string | undefined = undefined;


### PR DESCRIPTION
## 概要

#13 の対応になります。
~~(#11 の丁目の全角数字=>漢数字への置換対応も含んでいます。)~~ => リベースにより、mainブランチからの差分のみの形としました。

## 対応内容

町字マスターデータと町字マスター位置参照拡張データのマージ(Left Join)時に、データ不正が疑われる町字マスター位置参照拡張データ側の `rsdt_addr_flg` が利用されないよう、必要最小限のフィールド(`lg_code`, `machiaza_id`, `rep_lon`, `rep_lat`, `rep_srid`)に絞ってマージするようにしました。

本対応により、ローカル環境で焼津市の住所(`焼津市大村三丁目21-15`)が地番レベル(8)まで(ただし、位置座標は町字レベル(3))まで検索可能なことを確認済みです。
```sh
npm run cli 焼津市大村三丁目21-15
```
<details>
<summary>実行結果詳細</summary>

```json
{
  "pref": "静岡県",
  "city": "焼津市",
  "town": "大村三丁目",
  "addr": "21-15",
  "level": 8,
  "point": {
    "lat": 34.87306,
    "lng": 138.305336,
    "level": 3
  },
  "other": "",
  "metadata": {
    "input": "焼津市大村三丁目21-15",
    "prefecture": {
      "code": 220001,
      "pref": "静岡県",
      "pref_k": "シズオカケン",
      "pref_r": "Shizuoka",
      "point": [
        138.383023,
        34.976906
      ]
    },
    "city": {
      "code": 222127,
      "city": "焼津市",
      "city_k": "ヤイヅシ",
      "city_r": "Yaizu-shi",
      "point": [
        138.32326,
        34.866906
      ]
    },
    "machiAza": {
      "machiaza_id": "0016003",
      "oaza_cho": "大村",
      "oaza_cho_k": "オオムラ",
      "oaza_cho_r": "Omura",
      "chome": "三丁目",
      "chome_n": 3,
      "point": [
        138.305336,
        34.87306
      ]
    },
    "chiban": {
      "prc_num1": "21",
      "prc_num2": "15",
      "prc_num3": ""
    }
  }
}
```

</details>