### PR TITLE
04_make_chiban を最適化: Map ベースのマージ・並列処理・O(n²) 修正

### DIFF
--- a/src/lib/abr_data/index.test.ts
+++ b/src/lib/abr_data/index.test.ts
@@ -93,8 +93,10 @@ await describe('abr_data/index', async () => {
           ]);
         });
 
-        // 複合キーは _createKey が '|' 連結する。区切り文字を含む値で
-        // 別キー同士が衝突しないことを確認する。
+        // 複合キーは _createKey が '|' 連結する。先頭の lg_code だけが一致する行
+        // (011002|0001 と 012025|0001 など) が誤って結合されないことを確認する。
+        // なお値そのものに '|' が含まれるとキーが衝突し得るが、呼び出し元が渡すのは
+        // ABR の数字コード項目のみなので現れない (_createKey のコメント参照)。
         await test('it joins on composite keys', async () => {
           const one = async function *() {
             await Promise.resolve();

--- a/src/lib/abr_data/index.test.ts
+++ b/src/lib/abr_data/index.test.ts
@@ -1,83 +1,255 @@
 import assert from 'node:assert';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
 import test, { describe } from 'node:test';
 
 import * as index from './index.js';
 
+// mergeDataLeftJoin は memory 引数で実装が切り替わる。
+//   memory: false → 一時ファイル上の SQLite で LEFT JOIN
+//   memory: true  → 右側を Map に読み込み、左側をストリーム照合する高速パス
+// 通常の結合結果は両者で一致する必要があるため、同じケースを両経路で検証する。
+const JOIN_PATHS = [
+  { label: 'sqlite path (memory: false)', memory: false },
+  { label: 'in-memory Map path (memory: true)', memory: true },
+] as const;
+
 await describe('abr_data/index', async () => {
   await describe('joinAsyncIterators', async () => {
-    await test('it correctly joins two async iterators when they are ordered', async () => {
-      const one = async function*(){
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        yield *[
-          { id: 100, name: 'Alice' },
-          { id: 101, name: 'Bob' }
-        ];
+    for (const { label, memory } of JOIN_PATHS) {
+      await describe(label, async () => {
+        await test('it correctly joins two async iterators when they are ordered', async () => {
+          const one = async function*(){
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            yield *[
+              { id: 100, name: 'Alice' },
+              { id: 101, name: 'Bob' }
+            ];
+          };
+          const two = async function*(){
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            yield *[
+              { id: 100, age: 500 },
+              { id: 101, age: 501 }
+            ];
+          };
+
+          const res = await Array.fromAsync(
+            index.mergeDataLeftJoin(one(), two(), ['id'], memory)
+          );
+
+          assert.deepStrictEqual(res, [
+            { id: 100, name: 'Alice', age: 500 },
+            { id: 101, name: 'Bob', age: 501 },
+          ]);
+        });
+
+        await test('it correctly joins two async iterators when they are out of order', async () => {
+          const one = async function *() {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            yield *[{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }, { id: 3, name: 'Charlie' }];
+          };
+          const two = async function *() {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            yield *[{ id: 2, age: 30 }, { id: 1, age: 25 }, { id: 4, age: 35 }];
+          };
+
+          const res = await Array.fromAsync(
+            index.mergeDataLeftJoin(one(), two(), ['id'], memory)
+          );
+
+          assert.deepStrictEqual(res, [
+            { id: 1, name: 'Alice', age: 25 },
+            { id: 2, name: 'Bob', age: 30 },
+            { id: 3, name: 'Charlie' },
+          ]);
+        });
+
+        // 02_make_machi_aza などは lg_code が連続していることを前提に市区町村ごとの
+        // 出力ファイルを確定する。結合結果がキー順に並び替えられると、同じ市区町村を
+        // 複数回出力して後続の断片が先行ファイルを上書きしてしまう。
+        await test('it preserves the order of the left iterator', async () => {
+          const one = async function *() {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            yield *[
+              { id: 3, name: 'Charlie' },
+              { id: 1, name: 'Alice' },
+              { id: 2, name: 'Bob' },
+            ];
+          };
+          const two = async function *() {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            yield *[{ id: 1, age: 25 }, { id: 2, age: 30 }, { id: 3, age: 35 }];
+          };
+
+          const res = await Array.fromAsync(
+            index.mergeDataLeftJoin(one(), two(), ['id'], memory)
+          );
+
+          assert.deepStrictEqual(res, [
+            { id: 3, name: 'Charlie', age: 35 },
+            { id: 1, name: 'Alice', age: 25 },
+            { id: 2, name: 'Bob', age: 30 },
+          ]);
+        });
+
+        // 複合キーは _createKey が '|' 連結する。区切り文字を含む値で
+        // 別キー同士が衝突しないことを確認する。
+        await test('it joins on composite keys', async () => {
+          const one = async function *() {
+            await Promise.resolve();
+            yield *[
+              { lg_code: '011002', machiaza_id: '0001', name: 'A' },
+              { lg_code: '011002', machiaza_id: '0002', name: 'B' },
+              { lg_code: '012025', machiaza_id: '0001', name: 'C' },
+            ];
+          };
+          const two = async function *() {
+            await Promise.resolve();
+            yield *[
+              { lg_code: '012025', machiaza_id: '0001', lat: 43.0 },
+              { lg_code: '011002', machiaza_id: '0002', lat: 43.1 },
+            ];
+          };
+
+          const res = await Array.fromAsync(
+            index.mergeDataLeftJoin(one(), two(), ['lg_code', 'machiaza_id'], memory)
+          );
+
+          assert.deepStrictEqual(res, [
+            { lg_code: '011002', machiaza_id: '0001', name: 'A' },
+            { lg_code: '011002', machiaza_id: '0002', name: 'B', lat: 43.1 },
+            { lg_code: '012025', machiaza_id: '0001', name: 'C', lat: 43.0 },
+          ]);
+        });
+
+        await test('it yields the left rows unchanged when the right side is empty', async () => {
+          const one = async function *() {
+            await Promise.resolve();
+            yield *[{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }];
+          };
+          // 位置参照拡張データが存在しない市区町村では空のイテレータが渡される。
+          const two = async function *(): AsyncIterableIterator<{ id: number, age: number }> {};
+
+          const res = await Array.fromAsync(
+            index.mergeDataLeftJoin(one(), two(), ['id'], memory)
+          );
+
+          assert.deepStrictEqual(res, [
+            { id: 1, name: 'Alice' },
+            { id: 2, name: 'Bob' },
+          ]);
+        });
+      });
+    }
+
+    // SQLite パスは os.tmpdir() 配下に一時ディレクトリを作る。ジェネレータは yield 地点で
+    // 中断されるため、後始末を finally に置かないと消費側の break や例外で残留する。
+    await describe('temporary database cleanup on the sqlite path', async () => {
+      const TMP_PREFIX = 'merge-data-left-join-';
+      const countTmpDirs = async () => {
+        const entries = await fsp.readdir(os.tmpdir());
+        return entries.filter((entry) => entry.startsWith(TMP_PREFIX)).length;
       };
-      const two = async function*(){
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        yield *[
-          { id: 100, age: 500 },
-          { id: 101, age: 501 }
-        ];
-      };
 
-      const res = await Array.fromAsync(
-        index.mergeDataLeftJoin(one(), two(), ['id'])
-      );
-
-      assert.deepStrictEqual(res, [
-        { id: 100, name: 'Alice', age: 500 },
-        { id: 101, name: 'Bob', age: 501 },
-      ]);
-    });
-
-    await test('it correctly joins two async iterators when they are out of order', async () => {
-      const one = async function *() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+      const left = async function *() {
+        await Promise.resolve();
         yield *[{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }, { id: 3, name: 'Charlie' }];
       };
-      const two = async function *() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        yield *[{ id: 2, age: 30 }, { id: 1, age: 25 }, { id: 4, age: 35 }];
-      };
-
-      const res = await Array.fromAsync(
-        index.mergeDataLeftJoin(one(), two(), ['id'])
-      );
-
-      assert.deepStrictEqual(res, [
-        { id: 1, name: 'Alice', age: 25 },
-        { id: 2, name: 'Bob', age: 30 },
-        { id: 3, name: 'Charlie' },
-      ]);
-    });
-
-    // 02_make_machi_aza などは lg_code が連続していることを前提に市区町村ごとの
-    // 出力ファイルを確定する。結合結果がキー順に並び替えられると、同じ市区町村を
-    // 複数回出力して後続の断片が先行ファイルを上書きしてしまう。
-    await test('it preserves the order of the left iterator', async () => {
-      const one = async function *() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-        yield *[
-          { id: 3, name: 'Charlie' },
-          { id: 1, name: 'Alice' },
-          { id: 2, name: 'Bob' },
-        ];
-      };
-      const two = async function *() {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+      const right = async function *() {
+        await Promise.resolve();
         yield *[{ id: 1, age: 25 }, { id: 2, age: 30 }, { id: 3, age: 35 }];
       };
 
-      const res = await Array.fromAsync(
-        index.mergeDataLeftJoin(one(), two(), ['id'])
-      );
+      await test('it removes the temporary directory when the consumer breaks early', async () => {
+        const before = await countTmpDirs();
 
-      assert.deepStrictEqual(res, [
-        { id: 3, name: 'Charlie', age: 35 },
-        { id: 1, name: 'Alice', age: 25 },
-        { id: 2, name: 'Bob', age: 30 },
-      ]);
+        let seen = 0;
+        for await (const row of index.mergeDataLeftJoin(left(), right(), ['id'])) {
+          void row;
+          seen++;
+          break;
+        }
+
+        assert.strictEqual(seen, 1);
+        assert.strictEqual(await countTmpDirs(), before);
+      });
+
+      await test('it removes the temporary directory when the consumer throws', async () => {
+        const before = await countTmpDirs();
+
+        await assert.rejects(async () => {
+          for await (const row of index.mergeDataLeftJoin(left(), right(), ['id'])) {
+            void row;
+            throw new Error('consumer failed');
+          }
+        }, /consumer failed/);
+
+        assert.strictEqual(await countTmpDirs(), before);
+      });
+    });
+
+    // 以下は 2 つの経路で挙動が異なる箇所。どちらが正しいという話ではなく、
+    // 差分を明示して意図しない変化に気付けるようにするための特性テスト。
+    // memory: true を渡すのは 04_make_chiban.ts のみなので、影響範囲は地番の結合に限られる。
+    await describe('semantic differences between the two paths', async () => {
+      const left = async function *() {
+        await Promise.resolve();
+        yield *[{ id: 1, name: 'Alice' }];
+      };
+
+      // SQLite の LEFT JOIN は右側に同一キーが複数あると行が増える (ファンアウト) が、
+      // Map は最後の 1 件だけを保持するため 1 行に畳まれる。
+      await test('duplicate right-side keys fan out on the sqlite path', async () => {
+        const right = async function *() {
+          await Promise.resolve();
+          yield *[{ id: 1, age: 10 }, { id: 1, age: 20 }];
+        };
+
+        const res = await Array.fromAsync(
+          index.mergeDataLeftJoin(left(), right(), ['id'], false)
+        );
+
+        assert.deepStrictEqual(res, [
+          { id: 1, name: 'Alice', age: 10 },
+          { id: 1, name: 'Alice', age: 20 },
+        ]);
+      });
+
+      await test('duplicate right-side keys collapse to the last one on the Map path', async () => {
+        const right = async function *() {
+          await Promise.resolve();
+          yield *[{ id: 1, age: 10 }, { id: 1, age: 20 }];
+        };
+
+        const res = await Array.fromAsync(
+          index.mergeDataLeftJoin(left(), right(), ['id'], true)
+        );
+
+        assert.deepStrictEqual(res, [
+          { id: 1, name: 'Alice', age: 20 },
+        ]);
+      });
+
+      // SQLite パスの json_patch は値が null のキーを削除する RFC 7396 の挙動を持つが、
+      // Map パスの Object.assign は null をそのまま上書きする。
+      // 実際の CSV 由来のレコードは全フィールドが文字列 (Record<string, string>) なので
+      // 現状のパイプラインでは発生しないが、経路を差し替える際の注意点として残す。
+      await test('null right-side values delete the key on the sqlite path but survive on the Map path', async () => {
+        const right = async function *() {
+          await Promise.resolve();
+          yield *[{ id: 1, age: null }];
+        };
+
+        assert.deepStrictEqual(
+          await Array.fromAsync(index.mergeDataLeftJoin(left(), right(), ['id'], false)),
+          [{ id: 1, name: 'Alice' }],
+        );
+        assert.deepStrictEqual(
+          await Array.fromAsync(index.mergeDataLeftJoin(left(), right(), ['id'], true)),
+          [{ id: 1, name: 'Alice', age: null }],
+        );
+      });
     });
   });
 });

--- a/src/lib/abr_data/index.ts
+++ b/src/lib/abr_data/index.ts
@@ -11,13 +11,24 @@ function _createKey(data: any, keys: string[]): string {
 }
 
 export async function *mergeDataLeftJoin<T, U>(left: AsyncIterableIterator<T>, right: AsyncIterableIterator<U>, keys: string[], memory: boolean = false): AsyncIterableIterator<(T | T & U)> {
-  let tmpDbPath = ":memory:";
-
-  if (!memory) {
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "merge-data-left-join-"));
-    tmpDbPath = path.join(tmpDir, "db.sqlite3");
-    console.log(`Creating temporary database: ${tmpDbPath}`);
+  if (memory) {
+    // Fast path: load right side into a Map then stream left, avoiding SQLite and JSON round-trips.
+    const rightMap = new Map<string, U>();
+    for await (const data of right) {
+      rightMap.set(_createKey(data, keys), data);
+    }
+    for await (const data of left) {
+      const rightData = rightMap.get(_createKey(data, keys));
+      yield (rightData !== undefined
+        ? Object.assign({}, data, rightData)
+        : data) as T | (T & U);
+    }
+    return;
   }
+
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "merge-data-left-join-"));
+  const tmpDbPath = path.join(tmpDir, "db.sqlite3");
+  console.log(`Creating temporary database: ${tmpDbPath}`);
 
   const db = new Database(tmpDbPath);
   db.pragma("synchronous = OFF");
@@ -71,7 +82,5 @@ export async function *mergeDataLeftJoin<T, U>(left: AsyncIterableIterator<T>, r
   }
 
   db.close();
-  if (!memory) {
-    await fs.rm(path.dirname(tmpDbPath), { recursive: true });
-  }
+  await fs.rm(path.dirname(tmpDbPath), { recursive: true });
 }

--- a/src/lib/abr_data/index.ts
+++ b/src/lib/abr_data/index.ts
@@ -30,57 +30,63 @@ export async function *mergeDataLeftJoin<T, U>(left: AsyncIterableIterator<T>, r
   const tmpDbPath = path.join(tmpDir, "db.sqlite3");
   console.log(`Creating temporary database: ${tmpDbPath}`);
 
-  const db = new Database(tmpDbPath);
-  db.pragma("synchronous = OFF");
-  db.pragma("journal_mode = MEMORY");
-  db.exec(`
-    CREATE TABLE l (
-      key TEXT,
-      data JSONB
-    );
-    CREATE TABLE r (
-      key TEXT,
-      data JSONB
-    );
-  `);
-  const stmt1 = db.prepare("INSERT INTO l VALUES (?, ?)");
-  const stmt2 = db.prepare("INSERT INTO r VALUES (?, ?)");
+  // 消費側の early return / 反復中の例外でもハンドルと一時ディレクトリを解放するため、
+  // db 生成以降を try/finally で囲む。ジェネレータは yield 地点で中断されるので、
+  // finally の外に後始末を置くと到達しないことがある。
+  let db: Database.Database | undefined;
+  try {
+    db = new Database(tmpDbPath);
+    db.pragma("synchronous = OFF");
+    db.pragma("journal_mode = MEMORY");
+    db.exec(`
+      CREATE TABLE l (
+        key TEXT,
+        data JSONB
+      );
+      CREATE TABLE r (
+        key TEXT,
+        data JSONB
+      );
+    `);
+    const stmt1 = db.prepare("INSERT INTO l VALUES (?, ?)");
+    const stmt2 = db.prepare("INSERT INTO r VALUES (?, ?)");
 
-  await Promise.all([
-    pipeline(left, async function (source) {
-      for await (const data of source) {
-        stmt1.run(_createKey(data, keys), JSON.stringify(data));
-      }
-    }),
-    pipeline(right, async function (source) {
-      for await (const data of source) {
-        stmt2.run(_createKey(data, keys), JSON.stringify(data));
-      }
-    }),
-  ]);
-  db.exec(`
-    CREATE INDEX l_key ON l(key);
-    CREATE INDEX r_key ON r(key);
-  `);
+    await Promise.all([
+      pipeline(left, async function (source) {
+        for await (const data of source) {
+          stmt1.run(_createKey(data, keys), JSON.stringify(data));
+        }
+      }),
+      pipeline(right, async function (source) {
+        for await (const data of source) {
+          stmt2.run(_createKey(data, keys), JSON.stringify(data));
+        }
+      }),
+    ]);
+    db.exec(`
+      CREATE INDEX l_key ON l(key);
+      CREATE INDEX r_key ON r(key);
+    `);
 
-  // 呼び出し元 (02_make_machi_aza など) は lg_code が連続していることを前提に
-  // 市区町村ごとの出力ファイルを確定するため、左入力の順序を保つ必要がある。
-  // ORDER BY が無いと順序はクエリプラン任せ (l_key インデックス走査が選ばれると
-  // キー順になる) なので、挿入順である rowid 順を明示する。
-  // rowid 順のスキャンは l の自然順なので、追加のソートコストは発生しない。
-  const select = db.prepare<void[], {d01: string, d02: string}>(`
-    SELECT
-      json_patch(l.data, coalesce(r.data, '{}')) AS d01
-    FROM
-      l
-      LEFT JOIN r ON l.key = r.key
-    ORDER BY
-      l.rowid
-  `);
-  for (const data of select.iterate()) {
-    yield JSON.parse(data.d01);
+    // 呼び出し元 (02_make_machi_aza など) は lg_code が連続していることを前提に
+    // 市区町村ごとの出力ファイルを確定するため、左入力の順序を保つ必要がある。
+    // ORDER BY が無いと順序はクエリプラン任せ (l_key インデックス走査が選ばれると
+    // キー順になる) なので、挿入順である rowid 順を明示する。
+    // rowid 順のスキャンは l の自然順なので、追加のソートコストは発生しない。
+    const select = db.prepare<void[], {d01: string, d02: string}>(`
+      SELECT
+        json_patch(l.data, coalesce(r.data, '{}')) AS d01
+      FROM
+        l
+        LEFT JOIN r ON l.key = r.key
+      ORDER BY
+        l.rowid
+    `);
+    for (const data of select.iterate()) {
+      yield JSON.parse(data.d01);
+    }
+  } finally {
+    db?.close();
+    await fs.rm(tmpDir, { recursive: true, force: true });
   }
-
-  db.close();
-  await fs.rm(path.dirname(tmpDbPath), { recursive: true });
 }

--- a/src/lib/abr_data/index.ts
+++ b/src/lib/abr_data/index.ts
@@ -4,6 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
 
+// 結合キーを '|' 連結した文字列にする。値そのものに '|' が含まれると
+// ('a|b', 'c') と ('a', 'b|c') が同じキーになってしまうが、呼び出し元が渡すのは
+// lg_code / machiaza_id / prc_id / blk_id / rsdt_id / rsdt2_id といった
+// ABR の数字コード項目のみなので '|' は現れない。
+// キー項目に自由記述の文字列を追加する場合は曖昧さのない符号化に変えること。
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _createKey(data: any, keys: string[]): string {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/src/processes/03_make_rsdt.ts
+++ b/src/processes/03_make_rsdt.ts
@@ -28,12 +28,14 @@ type HeaderRow = {
 function serializeApiDataTxt(apiData: RsdtApi): { headerIterations: number, headerData: HeaderRow[], data: Buffer } {
   const outSections: Buffer[] = [];
   for ( const { machiAza, rsdts } of apiData ) {
-    let outSection = `住居表示,${machiAzaName(machiAza)}\n` +
-                     `blk_num,rsdt_num,rsdt_num2,lng,lat\n`;
+    const lines: string[] = [
+      `住居表示,${machiAzaName(machiAza)}`,
+      `blk_num,rsdt_num,rsdt_num2,lng,lat`,
+    ];
     for (const rsdt of rsdts) {
-      outSection += `${rsdt.blk_num || ''},${rsdt.rsdt_num},${rsdt.rsdt_num2 || ''},${rsdt.point?.[0] || ''},${rsdt.point?.[1] || ''}\n`;
+      lines.push(`${rsdt.blk_num || ''},${rsdt.rsdt_num},${rsdt.rsdt_num2 || ''},${rsdt.point?.[0] || ''},${rsdt.point?.[1] || ''}`);
     }
-    outSections.push(Buffer.from(outSection, 'utf8'));
+    outSections.push(Buffer.from(lines.join('\n') + '\n', 'utf8'));
   }
 
   const createHeader = (iterations = 1) => {

--- a/src/processes/04_make_chiban.test.ts
+++ b/src/processes/04_make_chiban.test.ts
@@ -38,6 +38,16 @@ await test.describe('resolveConcurrency', async () => {
     assert.equal(resolveConcurrency('0x10'), 4);
     assert.equal(resolveConcurrency('4 8'), 4);
   });
+
+  // 桁数が多すぎる入力は Number が Infinity を返す。`Infinity > 0` は真なので
+  // 弾かないと `executing.size >= CONCURRENCY` が常に false になり上限が消える。
+  await test('it rejects values too large to be a safe integer', () => {
+    assert.equal(resolveConcurrency('9'.repeat(400)), 4);
+    // 2^53 (Number.MAX_SAFE_INTEGER + 1)
+    assert.equal(resolveConcurrency('9007199254740992'), 4);
+    // 2^53 - 1 は安全な整数なので、そのまま通る境界値
+    assert.equal(resolveConcurrency('9007199254740991'), 9007199254740991);
+  });
 });
 
 await test.describe('with filter for 465054 (鹿児島県熊毛郡屋久島町)', async () => {

--- a/src/processes/04_make_chiban.test.ts
+++ b/src/processes/04_make_chiban.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import test from 'node:test';
 
 import fs from 'node:fs/promises';
-import main, { resolveConcurrency } from './04_make_chiban.js';
+import main, { resolveConcurrency, runWithConcurrency } from './04_make_chiban.js';
 import { getRangesFromCSV } from './10_refresh_csv_ranges.js';
 import { setupFixtureCache } from '../test_helpers/fixture_cache.js';
 
@@ -47,6 +47,106 @@ await test.describe('resolveConcurrency', async () => {
     assert.equal(resolveConcurrency('9007199254740992'), 4);
     // 2^53 - 1 は安全な整数なので、そのまま通る境界値
     assert.equal(resolveConcurrency('9007199254740991'), 9007199254740991);
+  });
+});
+
+// 1市区町村の失敗でプロセスが落ちる方針は維持するが、落ちる前に実行中の
+// 市区町村を書き切らせる必要がある。待たずに抜けると呼び出し元の process.exit(1) が
+// 書き込み中の -地番.txt を切り捨て、ヘッダーだけが揃った壊れたファイルが残る。
+await test.describe('runWithConcurrency', async () => {
+  await test('it never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runWithConcurrency(
+      Array.from({ length: 12 }, (_, i) => i),
+      4,
+      async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+      },
+    );
+    assert.equal(peak, 4);
+  });
+
+  await test('it calls onSettled once per item', async () => {
+    let settled = 0;
+    await runWithConcurrency(
+      Array.from({ length: 12 }, (_, i) => i),
+      4,
+      async () => {},
+      () => { settled += 1; },
+    );
+    assert.equal(settled, 12);
+  });
+
+  await test('it lets in-flight workers finish before rethrowing', async () => {
+    const started: number[] = [];
+    const finished: number[] = [];
+    await assert.rejects(
+      runWithConcurrency(
+        Array.from({ length: 12 }, (_, i) => i),
+        4,
+        async (i) => {
+          started.push(i);
+          if (i === 5) {
+            throw new Error('city 5 failed');
+          }
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          finished.push(i);
+        },
+      ),
+      /city 5 failed/,
+    );
+    // 起動した worker のうち、失敗した 5 以外はすべて完了していること。
+    // 実行中を待たない実装では、5 と同時に走っていたものが未完了のまま残る。
+    assert.deepStrictEqual(
+      finished.slice().sort((a, b) => a - b),
+      started.filter((i) => i !== 5),
+    );
+    // 失敗以降の市区町村は起動しない (中断する方針は変えていない)
+    assert.ok(started.length < 12, `started=${started.length}`);
+  });
+
+  // onSettled は .finally で呼ぶため、失敗した worker の分も1回呼ばれる。
+  // 進捗バーの母数が実際の起動数と合っている必要がある。
+  await test('it counts the failed worker in onSettled', async () => {
+    const started: number[] = [];
+    let settled = 0;
+    await assert.rejects(
+      runWithConcurrency(
+        Array.from({ length: 12 }, (_, i) => i),
+        4,
+        async (i) => {
+          started.push(i);
+          if (i === 5) {
+            throw new Error('city 5 failed');
+          }
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        },
+        () => { settled += 1; },
+      ),
+      /city 5 failed/,
+    );
+    assert.equal(settled, started.length);
+  });
+
+  // 実行中の worker が追加で失敗しても、投げ直すのは最初の例外にする。
+  // allSettled が後続の reject を吸うため unhandled rejection にもならない。
+  await test('it rethrows the first failure when another worker also fails', async () => {
+    await assert.rejects(
+      runWithConcurrency([0, 1, 2, 3], 4, async (i) => {
+        if (i === 0) {
+          throw new Error('first failure');
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        if (i === 1) {
+          throw new Error('second failure');
+        }
+      }),
+      /first failure/,
+    );
   });
 });
 

--- a/src/processes/04_make_chiban.test.ts
+++ b/src/processes/04_make_chiban.test.ts
@@ -2,9 +2,30 @@ import assert from 'node:assert';
 import test from 'node:test';
 
 import fs from 'node:fs/promises';
-import main from './04_make_chiban.js';
+import main, { resolveConcurrency } from './04_make_chiban.js';
 import { getRangesFromCSV } from './10_refresh_csv_ranges.js';
 import { setupFixtureCache } from '../test_helpers/fixture_cache.js';
+
+// CHIBAN_CONCURRENCY は同時実行数の上限になる。不正値がそのまま使われると
+// 上限チェックが機能しなくなるため、既定値に落とすことを保証する。
+await test.describe('resolveConcurrency', async () => {
+  await test('it uses a valid positive integer as-is', () => {
+    assert.equal(resolveConcurrency('1'), 1);
+    assert.equal(resolveConcurrency('8'), 8);
+  });
+
+  await test('it falls back to the default for unset, empty, or non-numeric values', () => {
+    assert.equal(resolveConcurrency(undefined), 4);
+    // 空文字列は ?? では拾われないため parseInt('') = NaN になる経路。
+    assert.equal(resolveConcurrency(''), 4);
+    assert.equal(resolveConcurrency('abc'), 4);
+  });
+
+  await test('it falls back to the default for zero and negative values', () => {
+    assert.equal(resolveConcurrency('0'), 4);
+    assert.equal(resolveConcurrency('-2'), 4);
+  });
+});
 
 await test.describe('with filter for 465054 (鹿児島県熊毛郡屋久島町)', async () => {
   test.before(() => {

--- a/src/processes/04_make_chiban.test.ts
+++ b/src/processes/04_make_chiban.test.ts
@@ -14,6 +14,10 @@ await test.describe('resolveConcurrency', async () => {
     assert.equal(resolveConcurrency('8'), 8);
   });
 
+  await test('it tolerates surrounding whitespace', () => {
+    assert.equal(resolveConcurrency(' 8 '), 8);
+  });
+
   await test('it falls back to the default for unset, empty, or non-numeric values', () => {
     assert.equal(resolveConcurrency(undefined), 4);
     // 空文字列は ?? では拾われないため parseInt('') = NaN になる経路。
@@ -24,6 +28,15 @@ await test.describe('resolveConcurrency', async () => {
   await test('it falls back to the default for zero and negative values', () => {
     assert.equal(resolveConcurrency('0'), 4);
     assert.equal(resolveConcurrency('-2'), 4);
+  });
+
+  // parseInt は末尾の不正文字を切り捨てるため、これらを弾かないと
+  // '1000workers' で同時実行数 1000 が通ってしまう。
+  await test('it rejects values that are only partially numeric', () => {
+    assert.equal(resolveConcurrency('1000workers'), 4);
+    assert.equal(resolveConcurrency('1.5'), 4);
+    assert.equal(resolveConcurrency('0x10'), 4);
+    assert.equal(resolveConcurrency('4 8'), 4);
   });
 });
 

--- a/src/processes/04_make_chiban.ts
+++ b/src/processes/04_make_chiban.ts
@@ -21,13 +21,15 @@ const DEFAULT_CONCURRENCY = 4;
 // (8GB ヒープでも足りない)。0 や負値は逆に毎回待機して直列化する。
 // parseInt は末尾の不正文字を切り捨てるため ('1000workers' → 1000、'1.5' → 1)、
 // 全体が正の整数であることを正規表現で確かめてから Number で変換する。
+// 桁数が多すぎる入力は Number が Infinity を返し (`'9'.repeat(400)` など)、
+// `Infinity > 0` は真なので上限消滅と同じ結果になる。isSafeInteger で弾く。
 export function resolveConcurrency(raw: string | undefined): number {
   const trimmed = raw?.trim() ?? '';
   if (!/^\d+$/.test(trimmed)) {
     return DEFAULT_CONCURRENCY;
   }
   const parsed = Number(trimmed);
-  return parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
 }
 
 const CONCURRENCY = resolveConcurrency(process.env.CHIBAN_CONCURRENCY);

--- a/src/processes/04_make_chiban.ts
+++ b/src/processes/04_make_chiban.ts
@@ -16,13 +16,18 @@ import { mergeDataLeftJoin } from '../lib/abr_data/index.js';
 const HEADER_CHUNK_SIZE = 50_000;
 const DEFAULT_CONCURRENCY = 4;
 
-// parseInt は不正値や空文字列に対して NaN を返す。NaN をそのまま使うと main 内の
-// `executing.size >= CONCURRENCY` が常に false になり同時実行数の上限が消えて、
-// 全市区町村の processCity が一斉に走ってしまう (8GB ヒープでも足りない)。
-// 0 や負値は逆に毎回待機して直列化するため、いずれも既定値に落とす。
+// 不正値をそのまま使うと main 内の `executing.size >= CONCURRENCY` が常に false になり
+// 同時実行数の上限が消えて、全市区町村の processCity が一斉に走ってしまう
+// (8GB ヒープでも足りない)。0 や負値は逆に毎回待機して直列化する。
+// parseInt は末尾の不正文字を切り捨てるため ('1000workers' → 1000、'1.5' → 1)、
+// 全体が正の整数であることを正規表現で確かめてから Number で変換する。
 export function resolveConcurrency(raw: string | undefined): number {
-  const parsed = parseInt(raw ?? '', 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
+  const trimmed = raw?.trim() ?? '';
+  if (!/^\d+$/.test(trimmed)) {
+    return DEFAULT_CONCURRENCY;
+  }
+  const parsed = Number(trimmed);
+  return parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
 }
 
 const CONCURRENCY = resolveConcurrency(process.env.CHIBAN_CONCURRENCY);

--- a/src/processes/04_make_chiban.ts
+++ b/src/processes/04_make_chiban.ts
@@ -202,6 +202,42 @@ async function processCity(
   ), apiData);
 }
 
+// items を最大 concurrency 個まで並行して worker に流す。
+// worker が reject したら、実行中の worker を待ってから最初の例外を投げ直す。
+// ここで待たずに抜けると、呼び出し元 (src/04_make_chiban.ts) の process.exit(1) が
+// 書き込み中の -地番.txt を切り捨て、ヘッダーだけが揃った壊れたファイルが残る。
+// その状態で 10_refresh_csv_ranges を通すと実体の無い領域を指す csv_ranges ができる。
+// 失敗以降の市区町村を起動しない (= 中断する) 方針は変えない。全国分が欠けたまま
+// 完走するほうが気付きにくいため。
+export async function runWithConcurrency<T>(
+  items: Iterable<T>,
+  concurrency: number,
+  worker: (item: T) => Promise<void>,
+  onSettled?: () => void,
+): Promise<void> {
+  const executing = new Set<Promise<void>>();
+  try {
+    for (const item of items) {
+      const p: Promise<void> = worker(item)
+        .finally(() => {
+          executing.delete(p);
+          onSettled?.();
+        });
+      executing.add(p);
+      if (executing.size >= concurrency) {
+        await Promise.race(executing);
+      }
+    }
+    await Promise.all(executing);
+  } catch (e) {
+    // 失敗した worker は .finally で executing から外れているため、ここで待つのは
+    // 実行中の残りだけ。allSettled は追加の失敗でも reject しないので、
+    // 最初の例外をそのまま投げ直せる。
+    await Promise.allSettled(executing);
+    throw e;
+  }
+}
+
 async function main(argv: string[]) {
   const outDir = argv[2] || path.join(import.meta.dirname, '..', '..', 'out', 'api');
   fs.mkdirSync(outDir, { recursive: true });
@@ -239,19 +275,12 @@ async function main(argv: string[]) {
   });
   progress.start(machiAzas.length, 0);
   try {
-    const executing = new Set<Promise<void>>();
-    for (const ma of machiAzas) {
-      const p: Promise<void> = processCity(ma, machiAzaDataByCode, outDir)
-        .finally(() => {
-          executing.delete(p);
-          progress.increment();
-        });
-      executing.add(p);
-      if (executing.size >= CONCURRENCY) {
-        await Promise.race(executing);
-      }
-    }
-    await Promise.all(executing);
+    await runWithConcurrency(
+      machiAzas,
+      CONCURRENCY,
+      (ma) => processCity(ma, machiAzaDataByCode, outDir),
+      () => progress.increment(),
+    );
   } finally {
     progress.stop();
   }

--- a/src/processes/04_make_chiban.ts
+++ b/src/processes/04_make_chiban.ts
@@ -14,6 +14,7 @@ import { ChibanData, ChibanPosData } from '../lib/abr_data/chiban.js';
 import { mergeDataLeftJoin } from '../lib/abr_data/index.js';
 
 const HEADER_CHUNK_SIZE = 50_000;
+const CONCURRENCY = parseInt(process.env.CHIBAN_CONCURRENCY ?? '4', 10);
 
 type ChibanApi = {
   machiAza: SingleMachiAza;
@@ -29,15 +30,17 @@ type HeaderRow = {
 function serializeApiDataTxt(apiData: ChibanApi): { headerIterations: number, headerData: HeaderRow[], data: Buffer } {
   const outSections: Buffer[] = [];
   for ( const { machiAza, chibans } of apiData ) {
-    let outSection = `地番,${machiAzaName(machiAza)}\n` +
-                     `prc_num1,prc_num2,prc_num3,lng,lat\n`;
+    const lines: string[] = [
+      `地番,${machiAzaName(machiAza)}`,
+      `prc_num1,prc_num2,prc_num3,lng,lat`,
+    ];
     for (const chiban of chibans) {
-      outSection += `${chiban.prc_num1},${chiban.prc_num2 || ''},${chiban.prc_num3 || ''},${chiban.point?.[0] || ''},${chiban.point?.[1] || ''}\n`;
+      lines.push(`${chiban.prc_num1},${chiban.prc_num2 || ''},${chiban.prc_num3 || ''},${chiban.point?.[0] || ''},${chiban.point?.[1] || ''}`);
     }
-    outSections.push(Buffer.from(outSection, 'utf8'));
+    outSections.push(Buffer.from(lines.join('\n') + '\n', 'utf8'));
   }
 
-  const createHeader = (iterations = 1) => {
+  const createHeader = (iterations = 1): { iterations: number, data: HeaderRow[], buffer: Buffer } => {
     let header = '';
     const headerMaxSize = HEADER_CHUNK_SIZE * iterations;
     let lastBytePos = headerMaxSize;
@@ -80,8 +83,6 @@ async function outputChibanData(outDir: string, outFilename: string, apiData: Ch
   if (apiData.length === 0) {
     return;
   }
-  // const machiAzaJSON = path.join(outDir, 'ja', outFilename + '.json');
-  // await fs.promises.writeFile(outFile, JSON.stringify(apiData, null, 2));
 
   const outFileTXT = path.join(outDir, 'ja', outFilename + '-地番.txt');
   const txt = serializeApiDataTxt(apiData);
@@ -89,6 +90,98 @@ async function outputChibanData(outDir: string, outFilename: string, apiData: Ch
   await fs.promises.writeFile(outFileTXT, txt.data);
 
   console.log(`${outFilename}: ${apiData.length.toString(10).padEnd(4, ' ')} 件の町字の地番を出力した`);
+}
+
+async function processCity(
+  ma: MachiAzaData,
+  machiAzaDataByCode: Map<string, MachiAzaData>,
+  outDir: string,
+): Promise<void> {
+  let area = `${ma.pref} ${ma.county}${ma.city}`;
+  if (ma.ward !== '') {
+    area += ma.ward;
+  }
+  const searchQuery = `${area} 地番マスター`;
+  const results = await getHubItemsByQuery(searchQuery, '市区町村レベル', ma.pref);
+  const chibanDataRef = findResultByTypeAndArea(results.features, '地番マスター', area);
+  const chibanPosDataRef = findResultByTypeAndArea(results.features, '地番マスター位置参照拡張', area);
+  // 検索結果が切り捨てられている場合、データセットは存在するのに枠外へ落ちている
+  // 可能性がある。「見つからない」というログだけでは「元々存在しない」と読めてしまい
+  // データ欠落に気づけないため、地番マスター・位置参照拡張のどちらが欠けた場合も明示する。
+  // 文言は hub.ts の warnIfTruncated と揃える。片方だけ言い回しが違うと、
+  // ログを grep したときに同じ事象の片側しか見つからない。
+  const truncationNote = mayBeTruncated(results)
+    ? `HUB API の検索結果を全件取得できませんでした `
+      + `(numberMatched: ${results.numberMatched ?? '不明'}, numberReturned: ${results.numberReturned})。`
+      + `データセットが存在するのに取得できていない可能性があります。`
+    : undefined;
+
+  if (!chibanDataRef) {
+    // 地番マスター自体が無いとこの市区町村は丸ごと出力されない
+    console.error(
+      `Insufficient data found for ${searchQuery} (地番マスター)`
+      + (truncationNote ? `。${truncationNote}` : '')
+    );
+    return;
+  }
+
+  if (!chibanPosDataRef) {
+    if (truncationNote) {
+      console.error(
+        `「${area} 地番マスター位置参照拡張」が検索結果に見つかりませんでした。${truncationNote}`
+      );
+    } else {
+      // 位置参照拡張が配信されていない市区町村もあるため、座標なしで続行する
+      console.warn(`「${area} 地番マスター位置参照拡張」は配信されていないため、座標なしで出力します`);
+    }
+  }
+
+  const mainStream = getAndStreamCSVDataForId<ChibanData>(chibanDataRef.properties.id);
+  const posStream = chibanPosDataRef ?
+    getAndStreamCSVDataForId<ChibanPosData>(chibanPosDataRef.properties.id)
+    :
+    // 位置参照拡張データが無い場合もある
+    (async function*() {})();
+
+  const rawData = mergeDataLeftJoin(mainStream, posStream, ['lg_code', 'machiaza_id', 'prc_id'], true);
+
+  let currentMachiAza: MachiAzaData | undefined = undefined;
+  const apiData: ChibanApi = [];
+  let currentChibanList: SingleChiban[] = [];
+  for await (const raw of rawData) {
+    const maEntry = machiAzaDataByCode.get(`${raw.lg_code}|${raw.machiaza_id}`);
+    if (!maEntry) {
+      continue;
+    }
+    if (currentMachiAza && (currentMachiAza.machiaza_id !== maEntry.machiaza_id || currentMachiAza.lg_code !== maEntry.lg_code)) {
+      apiData.push({
+        machiAza: rawToMachiAza(currentMachiAza),
+        chibans: currentChibanList,
+      });
+      currentChibanList = [];
+      currentMachiAza = maEntry;
+    }
+    if (!currentMachiAza) {
+      currentMachiAza = maEntry;
+    }
+
+    currentChibanList.push({
+      prc_num1: raw.prc_num1,
+      prc_num2: raw.prc_num2 !== '' ? raw.prc_num2 : undefined,
+      prc_num3: raw.prc_num3 !== '' ? raw.prc_num3 : undefined,
+      point: 'rep_srid' in raw ? projectABRData(raw) : undefined,
+    });
+  }
+  if (currentMachiAza && currentChibanList.length > 0) {
+    apiData.push({
+      machiAza: rawToMachiAza(currentMachiAza),
+      chibans: currentChibanList,
+    });
+  }
+  await outputChibanData(outDir, path.join(
+    ma.pref,
+    `${ma.county}${ma.city}${ma.ward}`,
+  ), apiData);
 }
 
 async function main(argv: string[]) {
@@ -106,19 +199,21 @@ async function main(argv: string[]) {
     `${ma.lg_code}|${ma.machiaza_id}`,
     ma
   ]));
+
+  // One representative entry per lg_code, in encounter order.
+  const seenLgCodes = new Set<string>();
   const machiAzas: MachiAzaData[] = [];
   for (const ma of machiAzaData) {
-    if (machiAzas.findIndex((c) => c.lg_code === ma.lg_code) > 0) {
-      continue;
-    }
+    if (seenLgCodes.has(ma.lg_code)) continue;
+    seenLgCodes.add(ma.lg_code);
     machiAzas.push(ma);
   }
   console.log('事前準備: 町字データを取得しました');
 
   const progress = new cliProgress.SingleBar({
     format: ' {bar} {percentage}% | ETA: {eta_formatted} | {value}/{total}',
-    barCompleteChar: '\u2588',
-    barIncompleteChar: '\u2591',
+    barCompleteChar: '█',
+    barIncompleteChar: '░',
     etaBuffer: 30,
     fps: 2,
     // No-TTY output is required for CI/CD environments
@@ -126,104 +221,19 @@ async function main(argv: string[]) {
   });
   progress.start(machiAzas.length, 0);
   try {
-
-    let currentLgCode: string | undefined = undefined;
+    const executing = new Set<Promise<void>>();
     for (const ma of machiAzas) {
-      if (currentLgCode && ma.lg_code === currentLgCode) {
-        // we have already processed this lg_code, so we can skip it
-        progress.increment();
-        continue;
-      } else if (currentLgCode !== ma.lg_code) {
-        currentLgCode = ma.lg_code;
-      }
-      let area = `${ma.pref} ${ma.county}${ma.city}`;
-      if (ma.ward !== '') {
-        area += `${ma.ward}`;
-      }
-      const searchQuery = `${area} 地番マスター`;
-      const results = await getHubItemsByQuery(searchQuery, '市区町村レベル', ma.pref);
-      const chibanDataRef = findResultByTypeAndArea(results.features, '地番マスター', area);
-      const chibanPosDataRef = findResultByTypeAndArea(results.features, '地番マスター位置参照拡張', area);
-      // 検索結果が切り捨てられている場合、データセットは存在するのに枠外へ落ちている
-      // 可能性がある。「見つからない」というログだけでは「元々存在しない」と読めてしまい
-      // データ欠落に気づけないため、地番マスター・位置参照拡張のどちらが欠けた場合も明示する。
-      // 文言は hub.ts の warnIfTruncated と揃える。片方だけ言い回しが違うと、
-      // ログを grep したときに同じ事象の片側しか見つからない。
-      const truncationNote = mayBeTruncated(results)
-        ? `HUB API の検索結果を全件取得できませんでした `
-          + `(numberMatched: ${results.numberMatched ?? '不明'}, numberReturned: ${results.numberReturned})。`
-          + `データセットが存在するのに取得できていない可能性があります。`
-        : undefined;
-
-      if (!chibanDataRef) {
-        // 地番マスター自体が無いとこの市区町村は丸ごと出力されない
-        console.error(
-          `Insufficient data found for ${searchQuery} (地番マスター)`
-          + (truncationNote ? `。${truncationNote}` : '')
-        );
-        progress.increment();
-        continue;
-      }
-
-      if (!chibanPosDataRef) {
-        if (truncationNote) {
-          console.error(
-            `「${area} 地番マスター位置参照拡張」が検索結果に見つかりませんでした。${truncationNote}`
-          );
-        } else {
-          // 位置参照拡張が配信されていない市区町村もあるため、座標なしで続行する
-          console.warn(`「${area} 地番マスター位置参照拡張」は配信されていないため、座標なしで出力します`);
-        }
-      }
-
-      const mainStream = getAndStreamCSVDataForId<ChibanData>(chibanDataRef.properties.id);
-      const posStream = chibanPosDataRef ?
-        getAndStreamCSVDataForId<ChibanPosData>(chibanPosDataRef.properties.id)
-        :
-        (async function*() {})();
-
-      const rawData = mergeDataLeftJoin(mainStream, posStream, ['lg_code', 'machiaza_id', 'prc_id'], true);
-      // console.log(`処理: ${ma.pref} ${ma.county}${ma.city} ${ma.ward} の地番データを処理中...`);
-
-      let currentMachiAza: MachiAzaData | undefined = undefined;
-      const apiData: ChibanApi = [];
-      let currentChibanList: SingleChiban[] = [];
-      for await (const raw of rawData) {
-        const ma = machiAzaDataByCode.get(`${raw.lg_code}|${raw.machiaza_id}`);
-        if (!ma) {
-          continue;
-        }
-        if (currentMachiAza && (currentMachiAza.machiaza_id !== ma.machiaza_id || currentMachiAza.lg_code !== ma.lg_code)) {
-          apiData.push({
-            machiAza: rawToMachiAza(currentMachiAza),
-            chibans: currentChibanList,
-          });
-          currentChibanList = [];
-          currentMachiAza = ma;
-        }
-        if (!currentMachiAza) {
-          currentMachiAza = ma;
-        }
-
-        currentChibanList.push({
-          prc_num1: raw.prc_num1,
-          prc_num2: raw.prc_num2 !== '' ? raw.prc_num2 : undefined,
-          prc_num3: raw.prc_num3 !== '' ? raw.prc_num3 : undefined,
-          point: 'rep_srid' in raw ? projectABRData(raw) : undefined,
+      const p: Promise<void> = processCity(ma, machiAzaDataByCode, outDir)
+        .finally(() => {
+          executing.delete(p);
+          progress.increment();
         });
+      executing.add(p);
+      if (executing.size >= CONCURRENCY) {
+        await Promise.race(executing);
       }
-      if (currentMachiAza && currentChibanList.length > 0) {
-        apiData.push({
-          machiAza: rawToMachiAza(currentMachiAza),
-          chibans: currentChibanList,
-        });
-      }
-      await outputChibanData(outDir, path.join(
-        ma.pref,
-        `${ma.county}${ma.city}${ma.ward}`,
-      ), apiData);
-      progress.increment();
     }
+    await Promise.all(executing);
   } finally {
     progress.stop();
   }

--- a/src/processes/04_make_chiban.ts
+++ b/src/processes/04_make_chiban.ts
@@ -14,7 +14,18 @@ import { ChibanData, ChibanPosData } from '../lib/abr_data/chiban.js';
 import { mergeDataLeftJoin } from '../lib/abr_data/index.js';
 
 const HEADER_CHUNK_SIZE = 50_000;
-const CONCURRENCY = parseInt(process.env.CHIBAN_CONCURRENCY ?? '4', 10);
+const DEFAULT_CONCURRENCY = 4;
+
+// parseInt は不正値や空文字列に対して NaN を返す。NaN をそのまま使うと main 内の
+// `executing.size >= CONCURRENCY` が常に false になり同時実行数の上限が消えて、
+// 全市区町村の processCity が一斉に走ってしまう (8GB ヒープでも足りない)。
+// 0 や負値は逆に毎回待機して直列化するため、いずれも既定値に落とす。
+export function resolveConcurrency(raw: string | undefined): number {
+  const parsed = parseInt(raw ?? '', 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
+}
+
+const CONCURRENCY = resolveConcurrency(process.env.CHIBAN_CONCURRENCY);
 
 type ChibanApi = {
   machiAza: SingleMachiAza;


### PR DESCRIPTION
## 概要

地番データ生成ステップ（`04_make_chiban`）のパフォーマンスを改善し、一部の修正を `03_make_rsdt` にも展開します。**実行速度の改善**と**重複排除の潜在バグ修正**が目的で、出力フォーマットは変更しません。

Refs #18

## 変更内容

### 1. `mergeDataLeftJoin` — Map ベースの高速パス（`src/lib/abr_data/index.ts`）

- `memory: true` 指定時、インメモリ SQLite をやめて右側を `Map` に読み込み、左側をストリーム照合する方式に変更
- 全行に発生していた `JSON.stringify` / `JSON.parse` のオーバーヘッドを解消
- ディスク上の SQLite パス（`memory: false`）は変更なし。一時ディレクトリの削除は常に実行するよう整理

### 2. `04_make_chiban` — 重複排除バグ修正 + 並列化（`src/processes/04_make_chiban.ts`）

- **O(n²) かつ不正な dedup を修正:** `machiAzas.findIndex((c) => c.lg_code === ma.lg_code) > 0` はインデックス `0` を除外できず O(n²) でもあったため、`Set<string>` に置き換え
- 1 市区町村分の処理を `processCity` ヘルパーに抽出
- 逐次処理から、上限付きの並列プール（デフォルト `4`、`CHIBAN_CONCURRENCY` 環境変数で変更可）に変更
- **並列化に伴う失敗時の in-flight 回収:** 1市区町村が失敗したとき、実行中の市区町村を書き切ってから例外を投げ直します（`runWithConcurrency`）。待たずに抜けると呼び出し元の `process.exit(1)` が書き込み中の `-地番.txt` を切り捨て、ヘッダーだけが揃った壊れたファイルが残り、`10_refresh_csv_ranges` が実体の無い領域を指す `csv_ranges` を作ってしまいます。失敗以降の市区町村を起動しない（中断する）方針は変えていません

### 3. `serializeApiDataTxt` — O(n²) の文字列生成を回避（`03_make_rsdt.ts` + `04_make_chiban.ts`）

- 文字列連結（`+=`）を `array.push` + `join('\n')` に変更し、大規模な町字での二次的な再割り当てを回避

## rebase について

元ブランチ（`18-optimize-chiban-performance`、base は `17-switch-abr-download-site`）を最新 `main` へ rebase したものです。元ブランチはそのまま残しています。

rebase にあたって以下を取り込み直しています。

- `mayBeTruncated` による HUB 検索結果の切り捨て警告（#29 で追加）を `processCity` 内へ移植。地番マスター／位置参照拡張のどちらが欠けた場合もログに出ます
- 地番データセット検索で `searchQuery` を再利用（文字列の二重組み立てを解消）
- `mergeDataLeftJoin` の SQLite パスにある `ORDER BY l.rowid`（左入力順の保持）は維持。Map パスは左をそのままストリームするため順序は構造的に保たれます
- 元ブランチで発生していたファイルモード変更（`100644` → `100755`）を `644` に戻し済み

## #30 との競合について

[#30](https://github.com/geolonia/japanese-addresses-v2/pull/30)（町字マスターの重複行ファンアウトとrsdtフラグ誤補正を解消）とは、**`src/lib/abr_data/index.ts` でテキスト上の競合が発生します**。解決は自明で、意味的な干渉はありません。

> **訂正:** 当初この節に「競合しません」「auto-merge 成功」と記載していましたが、誤りでした。@yuiseki さんのレビュー指摘を受けて3方向すべてを再実測し、実態に合わせて書き換えています。

### テキスト上の競合（発生します）

変更ファイルが重なるのは `src/lib/abr_data/index.ts` のみです。

- **#30**: SQLite の `SELECT` 内、`json_patch` 行の直上にコメントを1行追加
- **#33**: その `SELECT` を含むブロックごと `try` の中へ移動（インデント変更）、加えて関数冒頭の `memory: true` 分岐の新設と末尾の一時ディレクトリ削除

git の3方向マージは「ブロックの移動＋再インデント」と「ブロック内への行追加」を同時に解決できないため、#30 側の追加が1行だけでも競合します。3方向すべてで実測しました。

| 方向 | 結果 |
| --- | --- |
| #33 に #30 をマージ | `UU src/lib/abr_data/index.ts` |
| #30 に #33 をマージ | `UU src/lib/abr_data/index.ts` |
| #30 が先に main へ入った場合の #33 の rebase | `UU src/lib/abr_data/index.ts` |

**解決方法は #33 の構造（`try` の中に移動した `SELECT`）を採用したうえで、`json_patch` 行の直上に #30 のコメント行を戻すだけです。** マージ順序を問わず同じ1箇所の解決で済むため、マージの障害にはなりません。

### 意味的な競合（ありません）

`mergeDataLeftJoin` の呼び出し元のうち、**`memory: true` を渡すのは `04_make_chiban.ts` の1箇所だけ**です。#30 が修正対象にしている `02_make_machi_aza.ts` は第4引数を省略（`memory: false`）しているため SQLite パスを通ります。

つまり本 PR が新設する Map 高速パスは、#30 の重複行ファンアウト対策の経路には一切干渉しません。両者は同じ関数の中で排他的な分岐に住み分けています。

### 競合を解決したマージ後の動作確認

上記の解決を施した状態で確認しました。

```
npm run lint      # OK
npm run build:dev # OK
npm run test      # 115 tests / 113 pass / 0 fail / 2 skipped
```

マージ順序はどちらが先でも問題ありません。

## レビュー時の確認事項

- **Map パスと LEFT JOIN のセマンティクス差:** SQLite の `LEFT JOIN` は右側に同一キーが複数あると行が増える（ファンアウト）のに対し、`Map` は最後の1件だけを保持します。`memory: true` の呼び出し元は `04_make_chiban.ts` のみのため影響範囲は地番の結合に限られますが、地番マスター位置参照拡張に `lg_code|machiaza_id|prc_id` の重複がある場合に出力行数が変わり得る点はご確認ください。**この差分は下記のとおり特性テストで固定済みです**
- **`CHIBAN_CONCURRENCY` のデフォルト `4`:** 8GB ヒープ設定との兼ね合いで妥当か要確認
- 出力フォーマットは不変です

## CodeRabbit レビュー対応 1回目（c75d0ec）

Actionable 2件とも対応し、併せて Map パスのテストを追加しました。

### 1. `CHIBAN_CONCURRENCY` の検証（対応済み・指摘は妥当）

`parseInt` が `NaN` を返すと `executing.size >= CONCURRENCY` が常に false になり、同時実行数の上限が消滅します。スロットル部分を切り出して実測しました（12件投入時のピーク同時実行数）。

| `CHIBAN_CONCURRENCY` | `parseInt` | ピーク同時実行数 |
| --- | --- | --- |
| `4`（既定） | 4 | 4 |
| `abc` / `x8` | NaN | **12 = 全件同時** |
| `""`（空で export） | NaN | **12 = 全件同時** |
| `0` | 0 | 1（直列） |
| `-2` | -2 | 1（直列） |

`?? '4'` は空文字列を拾わないため、`CHIBAN_CONCURRENCY= npm run run:04_make_chiban` や CI が空変数を設定したケースでも NaN になります。

`resolveConcurrency()` として切り出して `export` し（モジュールスコープの `const` のままでは env 依存でテストできないため）、上記5パターンを単体テストで固定しました。なお指摘中の「`0` や負値でも同じ結果」は誤りで、0/負値は上限消滅ではなく直列化に倒れます。影響が正反対なのでコメントに区別を明記しています。

### 2. 一時 DB の `try`/`finally`（対応済み・ただし既存の挙動）

`db.close()` / `fs.rm` が `finally` の外にある点は事実なので修正しました。ただし **これは main 時点からの既存状態**で、本 PR は `if (!memory)` ガードを外しただけです。指摘中の severity 根拠2点は成立しません。

- 「この経路は常に一時ファイルを作るようになった」→ SQLite 分岐に入るのは `memory: false` の呼び出しのみで、一時ファイルを作る呼び出し集合は main と同一
- 「並列実行と組み合わせると残留物が蓄積」→ `memory: true` を渡すのは `04_make_chiban.ts:146` の1箇所だけなので、並列化された 04 は SQLite 経路に到達しません。残る利用者（`02_make_machi_aza.ts:52` と `abr_data/rsdtdsp_rsdt.ts:87`）はいずれも逐次

`break` / `return` で中断する消費側も現状存在しないため、実際に残留するのは例外パスのみです。堅牢化として妥当なので取り込みましたが、Major ではなく Minor 相当と判断しています。

実装は提案から1点変えており、`db` を `try` の外で `let db: Database.Database | undefined` として宣言し `db?.close()` にしています。`const db = new Database(tmpDbPath); try {` だと `new Database()` 自体が失敗したときに一時ディレクトリの回収が漏れるためです。

### 3. Map パスのテスト追加

**本 PR の主役である Map 高速パスが、既存テストで一度も実行されていませんでした**（3テストとも第4引数を省略）。以下を追加しています。

- 既存3テストを `JOIN_PATHS` でパラメータ化し、複合キー・右側が空の2ケースを追加 → **両経路 × 5ケース = 10テスト**。両パスが同じ結合結果を返すことを保証します
- 一時ディレクトリ回収の2テスト（`break` 時・例外時に `os.tmpdir()` 配下の `merge-data-left-join-*` 個数が増えないこと）
- 経路間のセマンティクス差の特性テスト3件

特性テストで判明した差分は2種類です。

| 右側の入力 | SQLite パス（`memory: false`） | Map パス（`memory: true`） |
| --- | --- | --- |
| 同一キーが複数 | 行が増える（ファンアウト） | 最後の1件に畳まれる |
| 値が `null` | `json_patch` がキーを**削除** | `Object.assign` が `null` を保持 |

`null` の挙動差は今回新たに判明したものです。CSV 由来のレコードは全フィールドが文字列（`Record<string, string>`、`src/lib/hub.ts` の `downloadAndExtract`）なので現行パイプラインでは発生しませんが、経路を差し替える際の注意点としてテストとコメントに残しました。

修正前の `index.ts` に差し替えると上記のうち4件が fail することを確認済みで、テストが空回りしていないことも検証しています。

## CodeRabbit レビュー対応 2回目（38293bc, 92f97f5）

1回目の修正に対する再レビューで Actionable 2件。**いずれも 1回目で私が追加したコードへの指摘**で、両方とも妥当でした。

### 4. `parseInt` の前方一致切り捨て（対応 → 38293bc）

`resolveConcurrency` の `Number.isInteger(parsed) && parsed > 0` だけでは不十分でした。`parseInt` は末尾の不正文字を切り捨てるためです。

```
"1000workers" -> 1000   ← 同時実行数 1000 が通ってしまう
"1.5"         -> 1
```

これはまさにこのガードが防ぐべき入力の種類なので、正規表現による全体一致に変更しました。

```ts
const trimmed = raw?.trim() ?? '';
if (!/^\d+$/.test(trimmed)) {
  return DEFAULT_CONCURRENCY;
}
const parsed = Number(trimmed);
return parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
```

> この時点の実装には桁あふれの穴が残っており、3回目のレビューで指摘されています（下記 6）。

`'1000workers'` / `'1.5'` / `'0x10'` / `'4 8'` が既定値になるテストを追加。`parseInt` から `Number` に変えると前後の空白が通らなくなるため `trim()` を挟み、`' 8 '` → `8` を維持するテストも足しています。

**上限値のキャップは意図的に入れていません。** 事故的な入力は上記で弾けますが、`CHIBAN_CONCURRENCY=999999` のような明示的な指定は運用者の判断として尊重すべきと考えています（市区町村数 ~1900 で頭打ちになります）。この方針はレビューでも了承されています。

### 5. 複合キーテストのコメント不一致（対応 → 92f97f5）

1回目で追加したテストのコメントが「`|` を含む値での衝突を検証する」と書いていたのに、テストデータに `|` が含まれていないという指摘です。**コメント側の誤りでした**ので、実際の検証内容に合わせて修正しました。

このテストが実際に検証しているのは「先頭の `lg_code` だけが一致する行が誤って結合されないこと」です。左の `(011002, 0001, A)` は `lg_code` が右の `(011002, 0002)` と一致し、`machiaza_id` が右の `(012025, 0001)` と一致するため、片方の項目だけで結合されると A に `lat` が付いてしまいます。A が未結合で残ることで複合キー全体での照合が確認できます。

**衝突テストの追加と `_createKey` の符号化変更は見送りました。**

- ご提案の `['a|b', 'c']` と `['a', 'b|c']` は確かに同じキー `"a|b|c"` になり、提案どおりのテストは fail します（実測確認済み）
- しかし本番の呼び出し元が渡すキー項目は `['lg_code', 'machiaza_id']` / `['lg_code', 'machiaza_id', 'prc_id']` / `['lg_code', 'machiaza_id', 'blk_id', 'rsdt_id', 'rsdt2_id']` の3通りだけで、いずれも ABR の数字コード項目です。`|` は構造的に現れません
- `_createKey` は全行が通るホットパスで、本 PR はそのオーバーヘッド削減が目的です。到達不能なケースのために JSON 符号化などを挟むのは目的に反します

代わりに `_createKey` の定義側に前提と、前提が崩れる条件を明記しました。キー項目に自由記述の文字列を追加する変更をする人が最初に読む場所なので、fail するテストを置くより実用的と判断しています。この判断はレビューでも受け入れられ、元の指摘は取り下げられました。

### レビュースレッドの状態

Actionable 4件すべて対応済みで、4スレッドとも resolved です。1回目の2件については、CodeRabbit 側から以下の訂正を得ています。

- `CHIBAN_CONCURRENCY`: 「`0` と負値は上限を無効化しません。元のコメントのこの部分は不正確でした」
- 一時 DB: 「元の severity 根拠は正確ではありませんでした」（既存の挙動である点、並列処理が SQLite 経路に到達しない点を含め3点すべて）

## CodeRabbit レビュー対応 3回目（4887e41）

### 6. 桁あふれによる `Infinity`（対応 → 4887e41）

**2回目の修正（38293bc）で私が作り込んだリグレッションでした。**

`/^\d+$/` を通れば整数であることは保証されるので `Number.isInteger` は冗長と判断して外したのですが、桁数が多すぎる入力で `Number` が `Infinity` を返すケースを見落としていました。

```
1つ前の実装 (c75d0ec): parseInt + Number.isInteger
  '9'.repeat(400) -> 4   (parseInt = Infinity, isInteger(Infinity) = false で弾けていた)

2回目の実装 (38293bc): regex + Number
  '9'.repeat(400) -> Infinity   ← 通ってしまう

スロットルへの影響:
  executing.size >= Infinity -> false（常に false = 上限消滅）
```

効果は `NaN` のときと同一（同時実行数の上限が消える）なので、Major の評価も妥当です。`Number.isSafeInteger` を追加しました。

```ts
const parsed = Number(trimmed);
return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_CONCURRENCY;
```

回帰テスト3ケースを追加しています。

| 入力 | 結果 |
| --- | --- |
| `'9'.repeat(400)` | `4`（既定値） |
| `'9007199254740992'`（2^53） | `4`（既定値） |
| `'9007199254740991'`（2^53 - 1） | そのまま通る境界値 |

## 動作確認

```
npm run lint      # OK
npm run build:dev # OK
npm run test      # 85 tests / 83 pass / 0 fail / 2 skipped（2件は network テスト）
```

レビュー対応前は 65 pass だったので、追加した18テストが加わった数字です。屋久島町のフィクスチャを使う既存の 04 統合テスト（Map パスを実データで通す唯一のテスト）も通っています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 大量の住所・地番データ処理を高速化しました。
  * 市区町村単位の処理を並列化し、処理時間を短縮しました。
  * 同時実行数を環境設定で調整できるようになりました。不正な設定値には既定値を適用します。
  * 結合処理の安定性を向上し、重複キーや空値を適切に処理できるようになりました。
  * 一時データの後処理を改善し、不要なデータが残りにくくなりました。
  * CSV生成処理を安定化しました。出力内容や空値の扱いに変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




