### PR TITLE
npm 公開を OIDC の Trusted Publishing に移行し、GitHub Actions を更新する

### DIFF
--- a/.github/workflows/create-data.yml
+++ b/.github/workflows/create-data.yml
@@ -6,6 +6,10 @@ on:
   #   - cron: '0 0 * * *'
   workflow_dispatch:
 
+# 既定は読み取りのみ。追加の権限が必要なジョブでだけ個別に宣言する
+permissions:
+  contents: read
+
 jobs:
   create-data:
     runs-on: ubuntu-latest
@@ -29,27 +33,34 @@ jobs:
           sudo df -h
           echo
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          # どのジョブも git 認証を使わないため、認証情報をワークツリーに残さない
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'npm'
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           key: 'v1'
           path: cache
 
+      # NOTE: このジョブは id-token: write を持つため ACTIONS_ID_TOKEN_REQUEST_* が全ステップに
+      # 露出しており、npm ci が走らせる better-sqlite3 などの install スクリプトから
+      # AWS ロールを引き受けられる状態にある。生成物 out/api が巨大でジョブ間の受け渡しが
+      # 現実的でないため分割していない。絞り込む場合は AWS ロールの信頼ポリシー側で行う。
       - name: Install dependencies
         run: npm ci
 
       - name: Create all data
         run: npm run run:all
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
@@ -74,7 +85,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          # どのジョブも git 認証を使わないため、認証情報をワークツリーに残さない
+          persist-credentials: false
 
       - name: Clear Cloudflare cache
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,26 +1,53 @@
 name: Auto Release
 
-permissions:
-  contents: write
 on:
   push:
     tags:
       - 'v*.*.*'
 
+# 既定は読み取りのみ。書き込みが必要なジョブでだけ個別に宣言する
+permissions:
+  contents: read
+
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
+
+    outputs:
+      prerelease: ${{ steps.meta.outputs.prerelease }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
+        with:
+          # このジョブは git 認証を使わないため、認証情報をワークツリーに残さない
+          persist-credentials: false
+
+      # 公開されるバージョンは package.json 由来、dist-tag の判定はタグ名由来のため、
+      # 両者がずれていると意図しない dist-tag で公開される。
+      # npm ci より前に置いて、ミスタグのときは数秒で落とす。
+      # setup-node より前だが、ランナーには Node が同梱されているため node -p は動く。
+      - name: タグを検証して公開メタデータを決める
+        id: meta
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          PKG="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::タグ $TAG が package.json の version $PKG と一致しません"
+            exit 1
+          fi
+          # ${TAG%%+*} でビルドメタデータを落とす。その中のハイフンは prerelease ではない。
+          case "${TAG%%+*}" in
+            *-*) PRERELEASE=true ;;
+            *)   PRERELEASE=false ;;
+          esac
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG prerelease=$PRERELEASE"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@geolonia'
           cache: 'npm'
 
       - name: Install dependencies
@@ -29,14 +56,107 @@ jobs:
       - name: Build
         run: npm run build
 
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist
+
+  release:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      # ファイルを添付しないため checkout は不要（tag_name から API で Release を作る）
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
+          prerelease: ${{ needs.build.outputs.prerelease }}
 
-      - name: Publish to npm
-        run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  publish:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    # id-token: write は npm の Trusted Publishing (OIDC) に必要
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          # Node.js 24.x が同梱する npm は、OIDC 公開に必要な 11.5.1 以降を満たす。
+          # 22.x 同梱の npm (10.9.x) は満たさないため、このジョブに限り 24.x を使う。
+          # setup-node は v7 でダミーの NODE_AUTH_TOKEN を export しなくなった。
+          # これが OIDC 公開の前提なので、v6 以下に戻さないこと。
+          node-version: 24.x
+          # 既定ではランナーのツールキャッシュにある 24.x が優先され、同梱される npm の
+          # バージョンがキャッシュの内容に左右される。要件を満たす版を確実に取るため最新を取る
+          check-latest: true
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@geolonia'
+          # このジョブは npm ci をしないためキャッシュ不要。公開ジョブでのキャッシュ汚染も避ける
+          package-manager-cache: false
+
+      # npm 11.5.1 未満では OIDC 公開ができない。NODE_AUTH_TOKEN も渡していないため、
+      # そのまま進むと原因の分かりにくい認証エラーになる。理由が分かる形で先に落とす。
+      - name: npm が OIDC 公開の要件を満たすか確認する
+        run: |
+          NPM_VERSION="$(npm --version)"
+          REQUIRED=11.5.1
+          # 文字列比較では 11.16.0 < 11.5.1 と誤判定するため sort -V で比較する
+          if [ "$(printf '%s\n%s\n' "$REQUIRED" "$NPM_VERSION" | sort -V | head -n1)" != "$REQUIRED" ]; then
+            echo "::error::npm $NPM_VERSION は OIDC 公開に必要な $REQUIRED 未満です"
+            exit 1
+          fi
+          echo "npm $NPM_VERSION (>= $REQUIRED)"
+
+      # npm publish は package.json を必要とするため checkout する
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # dist は build ジョブの成果物をそのまま使い、このジョブでは npm ci をしない。
+      # このジョブは id-token: write を持つため ACTIONS_ID_TOKEN_REQUEST_* が全ステップに
+      # 露出しており、ここで依存をインストールすると better-sqlite3 / esbuild / fsevents の
+      # install スクリプトが「Trusted Publisher として公開できる環境」で走ってしまう。
+      # 侵害された依存の postinstall にその力を渡さないため、依存のコードを一切実行しない。
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      # package.json の prepack (clean && build) は下の --ignore-scripts で飛ばすため、
+      # dist の中身は誰も保証しない。空パッケージを公開しないよう明示的に確認する。
+      - name: dist の中身を確認する
+        run: |
+          for f in dist/cjs/data.cjs dist/esm/data.mjs dist/esm/data.d.ts; do
+            if [ ! -s "$f" ]; then
+              echo "::error::$f が存在しないか空です"
+              exit 1
+            fi
+          done
+          ls -l dist/cjs dist/esm
+
+      # --ignore-scripts で prepack を飛ばす。prepack は npm run clean && npm run build を
+      # 呼ぶが、このジョブには node_modules が無いため tsc が見つからず失敗する。
+      # 手元の npm pack が古い dist を同梱しないよう prepack 自体は残している。
+      # --provenance は明示的に付ける。npm の自動有効化は前提を満たさないとき
+      # エラーではなく黙って provenance なしで公開するため、意図しない無効化を防ぐ。
+      - name: 公開 (latest)
+        if: needs.build.outputs.prerelease == 'false'
+        run: npm publish --access=public --provenance --ignore-scripts
+
+      # prerelease は next dist-tag に公開し、npm install の既定や ^/~ の範囲に入れない
+      - name: 公開 (next)
+        if: needs.build.outputs.prerelease == 'true'
+        run: npm publish --access=public --provenance --ignore-scripts --tag=next

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,21 +10,28 @@ on:
       - main
       - next
 
+# このワークフローは読み取りしか行わない
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          # git 認証を使わないため、認証情報をワークツリーに残さない
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: 'npm'
 
       - name: Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           key: v1-${{ hashFiles('src/**') }}
           path: cache

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.0.5",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/geolonia/japanese-addresses-v2.git"
+  },
   "exports": {
     "import": "./dist/esm/data.mjs",
     "require": "./dist/cjs/data.cjs",
@@ -37,6 +41,11 @@
   "files": [
     "dist/**/*"
   ],
+  "allowScripts": {
+    "better-sqlite3": true,
+    "esbuild": true,
+    "fsevents": true
+  },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@geolonia/japanese-numeral": "^1.0.2",


### PR DESCRIPTION
## 概要

npm の長期トークン廃止（クラシックトークンの失効・granular トークンの短命化）に対応するため、
GitHub Actions からの publish を **OIDC による Trusted Publishing** へ移行します。
あわせて Actions の各アクションを最新のメジャーへ更新し、権限まわりを引き締めます。

geolonia/japanese-numeral#25、geolonia/normalize-japanese-addresses#282 と同じ方針です。

なお **AWS 認証は既に OIDC 済み**です（`create-data.yml` の `id-token: write` +
`configure-aws-credentials` の `role-to-assume`）。本リポジトリに残っていた長期クレデンシャルは
`secrets.NPM_TOKEN` と `secrets.CLOUDFLARE_PURGE_TOKEN` で、後者は Cloudflare が OIDC 非対応の
ため残置します。今回廃止するのは `NPM_TOKEN` です。

## 変更内容

### `.github/workflows/create-release.yml` — 1 ジョブを 3 ジョブに分割

従来は 1 ジョブが checkout → `npm ci` → build → GitHub Release 作成 → `npm publish` を
すべて行っていました。これを `build` / `release` / `publish` に分けます。

| ジョブ | permissions | 役割 |
| --- | --- | --- |
| `build` | `contents: read` | タグ検証・ビルド・`dist` の artifact 化 |
| `release` | `contents: write` | GitHub Release の作成 |
| `publish` | `id-token: write` / `contents: read` | npm への OIDC 公開 |

分割の主目的は `publish` ジョブから依存のコード実行を完全に排除することです。
このジョブは `id-token: write` を持つため `ACTIONS_ID_TOKEN_REQUEST_*` が全ステップに露出します。
ここで `npm ci` すると `better-sqlite3` / `esbuild` / `fsevents` の install スクリプトが
「Trusted Publisher として npm に公開できる環境」で実行されてしまいます。
侵害された依存の postinstall にその力を渡さないため、`publish` ジョブは `build` が上げた
`dist` artifact をダウンロードするだけで、`node_modules` を一切用意しません。

#### `npm publish` に `--ignore-scripts` を付けている理由

**参考 PR との最大の相違点です。** normalize-japanese-addresses#282 では
「`prepack` / `prepublishOnly` が無いので `npm publish` は `node_modules` を必要としない」
という前提で `npm ci` を外していましたが、本リポジトリには

```json
"prepack": "npm run clean && npm run build"
```

があるため、`npm publish` がそのまま `tsc` を呼び、`node_modules` の無い `publish` ジョブでは
`code 127` で失敗します（ローカルで実測）。そのため `--ignore-scripts` で `prepack` を飛ばします。

`prepack` 自体は削除していません。削除すると手元の `npm pack` が古い `dist` を黙って同梱する
ようになるためです。CI 側だけ迂回し、代わりに公開直前に `dist` の 3 ファイルが存在し 0 バイトで
ないことを確認するステップを入れて、artifact が壊れていた場合に空パッケージを公開しないように
しています。

#### その他 `publish` ジョブ

- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` を削除しました
- `node-version: 24.x` + `check-latest: true`。OIDC 公開には npm >= 11.5.1 が必要で、
  Node 22.x 同梱の npm (10.9.x) は要件を満たしません。`check-latest` を付けないとランナーの
  ツールキャッシュ次第で要件未満の npm を掴む可能性があります（Node 24.0.0 同梱は npm 11.3.0）
- npm のバージョン検証ステップを追加しました。要件未満なら理由の分かる形で先に失敗させます
  （`NODE_AUTH_TOKEN` を渡していないため、そのまま進むと原因の分かりにくい認証エラーになります）
- `setup-node` は v7 で「ダミーの `NODE_AUTH_TOKEN` を export しない」変更が入っており、
  これが OIDC 公開の前提です。**v6 以下に戻さないでください**（コードにもコメントで明記しています）
- `package-manager-cache: false`（このジョブは `npm ci` をせず、キャッシュ汚染も避けたいため）
- `--provenance` は明示的に付けています。npm の自動有効化は前提を満たさないときエラーではなく
  黙って provenance なしで公開する挙動があるためです

#### タグ検証と prerelease 判定

`build` ジョブの先頭（`npm ci` より前）で、`GITHUB_REF` のタグ名と `package.json` の `version` の
一致を検証します。不一致ならここで止めます。あわせてビルドメタデータ（`+...`）を除いたタグに
ハイフンが含まれるかで prerelease を判定し、ジョブ output として `release` / `publish` の両方に渡します。

`publish` は prerelease 判定で 2 ステップに分岐します。

- 通常タグ（`v0.0.6` 等）→ `npm publish --access=public --provenance --ignore-scripts`（`latest`）
- prerelease タグ（`v0.0.6-rc.0` 等）→ 同上 + `--tag=next`（`npm install` の既定解決や `^`/`~` の
  範囲に入らないようにします）

`release` にも同じ判定結果を渡し、GitHub Release にも prerelease フラグが立つようにしました。

参考 PR では release と publish が別ワークフローだったため `steps.outputs` を共有できず、
検証ロジックを 2 箇所に複製していました。本リポジトリは 1 ワークフロー内なので `needs` +
ジョブ output で 1 箇所に集約でき、かつ **ビルドが通らない限り Release が作られない**構成に
なっています。

### `package.json`

- `repository` を追加しました。**これが無いと provenance 公開は失敗します。**
  provenance の attestation 自体は CI の環境変数から組み立てられますが、npm レジストリ側が
  公開時に `package.json` の `repository.url` と attestation が指すリポジトリを突き合わせるためです。
- `allowScripts` に `better-sqlite3` / `esbuild` / `fsevents` を追加しました。
  npm は install スクリプトを許可制にする移行を進めており、**npm 12 では `allowScripts` に
  列挙されていない install スクリプトは黙ってスキップされます**。
  これには `binding.gyp` を持つパッケージへの暗黙の `node-gyp rebuild` も含まれるため、
  列挙しないと npm 12 環境で `better-sqlite3` のネイティブバイナリが用意されず、
  データ生成パイプラインが動かなくなります。
  現行の npm 11.x では advisory な段階で、効果は「`npm warn install-scripts` の警告を消すこと」と
  「npm 12 への備え」の 2 点です。

### `.github/workflows/create-data.yml`

AWS 認証は既に OIDC のため、アクションのメジャー更新と権限の引き締めのみです。

- `actions/checkout` v4 → v7、`actions/setup-node` v4 → v7、`actions/cache` v4 → v6、
  `aws-actions/configure-aws-credentials` v4 → v6
- ワークフロー最上位に `permissions: contents: read` を追加
- checkout に `persist-credentials: false` を追加（どのジョブも git 認証を使わず、
  `package-lock.json` に git 由来の依存もありません）

**既知の残存リスクをコメントとして記録しました。** `create-data` ジョブは `id-token: write` を
持ったまま `npm ci` を実行しており、`publish` ジョブで排除したのと同じ露出があります。
分割するには生成物 `out/api`（数 GB）をジョブ間で受け渡す必要があり現実的でないため、
本 PR では構造を変えていません。絞り込むなら AWS ロールの信頼ポリシー側の対応になります。

### `.github/workflows/test.yml`

- 最上位に `permissions: contents: read`、checkout に `persist-credentials: false`
- `actions/checkout` v4 → v7、`actions/setup-node` v4 → v7、`actions/cache` v4 → v6
- Node は 22 単一のまま（`.tool-versions` の 22.9.0 と `better-sqlite3` の前提に合わせています）

## 動作確認

### ローカル

- `npm run lint` / `npm run typecheck` / `npm run test`（67 件、fail 0）
- `actionlint` 1.7.12（**shellcheck 併用**）で 3 ワークフローとも指摘なし。
  shellcheck が入っていないと `run:` の中身が黙ってスキップされるため、入れた状態で実行しています
- タグ検証・prerelease 判定・npm バージョン比較・`dist` 存在チェックの各 shell ロジックを
  ケース別に単体実行しました。特に以下を確認しています
  - `v1.0.0+2026-08-20` のようにビルドメタデータ内にハイフンがある場合に prerelease と誤判定しない
  - `v0.0.5` と `0.0.50` を一致と誤判定しない
  - npm のバージョン比較で `11.16.0` を `11.5.1` 未満と誤判定しない（`sort -V` を使う理由）
  - `dist` のファイルが 0 バイトの場合も NG になる
- `node_modules` の無いディレクトリで `npm pack --dry-run --ignore-scripts` が成功し、
  `dist/**` が tarball に含まれることを確認しました
- `allowScripts` は npm 11.19.0 で A/B 検証しました。フィールド無しだと
  `better-sqlite3@11.7.2` / `esbuild@0.23.1` / `fsevents@2.3.3` の 3 件が
  `install scripts not yet covered by allowScripts` として警告され、追加すると警告が消えます。
  列挙すべきパッケージが過不足なくこの 3 件であることも同時に確認できています

### fork での実測

fork（`sanak/japanese-addresses-v2`）に実際にタグを push して確認しました。
`npm publish` は `--dry-run` に差し替えています（fork ではパッケージ名が同一のため実公開は不可）。

| ケース | `build` | `release` | `publish` | 結果 |
| --- | --- | --- | --- | --- |
| ミスタグ `v9.9.9`（`package.json` は `0.0.5`） | ❌ タグ検証で失敗 | skipped | skipped | **GitHub Release は作られない**。`npm ci` にも到達しない |
| prerelease `v0.0.6-rc.0` | ✅ | ✅ Pre-release フラグ付き | ✅ `公開 (next)` のみ実行 | `Publishing ... with tag next` |
| 通常タグ `v0.0.6` | ✅ | ✅ 通常 Release | ✅ `公開 (latest)` のみ実行 | `Publishing ... with tag latest` |

- ミスタグのケースでは `build` がステップ 3（タグ検証）で落ち、`Install dependencies` 以降は
  すべて `skipped` でした。`better-sqlite3` のネイティブビルドを待たずに数秒で失敗します
- `publish` ジョブは Node 24.19.0 / **npm 11.17.0** で動作し、要件 11.5.1 を満たしました
- `test.yml` も fork の PR で実行し、checkout@v7 / setup-node@v7 / cache@v6 で全ステップ成功しました
- 検証に使ったタグ・Release・ブランチは削除済みです

### 確認できていないこと

**OIDC の実ハンドシェイクと provenance の attestation 送信は、本 PR をマージして本番でタグを
打つまで確認できません。** `--dry-run` では sigstore / attestation 関連の出力が一切無く、
確認できたのは「dist-tag の分岐が正しいこと」「`EUSAGE` にならないこと」までです。
これは参考 PR (#282) と同じ制約です。

## マージ前の前提（要対応）

- [ ] npmjs.com で `@geolonia/japanese-addresses-v2` の **Trusted Publisher** を設定してください
  - org: `geolonia`
  - repo: `japanese-addresses-v2`
  - workflow filename: `create-release.yml`（パスなし。`npm publish` を実行するのはこのワークフローです）
  - environment: 空
  - Allowed actions: `npm publish`（必須項目です。未選択だと公開が失敗します）

npm が突合するのはリポジトリとワークフローファイル名なので参照する ref がタグでも問題ありませんが、
公開に使うワークフローの内容を確定させてからタグを打ちたいため、本 PR を先にマージしてから
リリースタグを push する運用にします。

## このPRのスコープについて

`create-data.yml` と `test.yml` は `npm publish` を実行しないため、#23 の記述だけを見ると
対象外に見えます。これらを本 PR に含めているのは、#23 の目的である「長期クレデンシャルの排除」と
同じ作業単位として、ワークフロー全体の権限を最小化するためです。両ファイルへの変更は以下に限られます。

- 最上位への `permissions: contents: read` の追加（既定を読み取りのみにする）
- checkout への `persist-credentials: false` の追加（git 認証情報をワークツリーに残さない）
- 各アクションのメジャー更新（上記と同じファイル・同じレビュー単位で行うため同時に実施）

別 PR に分けると同じ `.github/workflows/` を対象とする PR が並行し、マージ順の調整と
コンフリクトの管理コストが増えます。変更が上記3点に限られ、いずれも権限の縮小方向であることから、
本 PR にまとめています。

## 後続作業（別対応）

- 初回 OIDC 公開の成功確認後に `NPM_TOKEN` シークレットを削除します（それまではロールバック用に残置）
- `CLOUDFLARE_PURGE_TOKEN` は Cloudflare が OIDC 非対応のため残置します

Closes #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リリース改善**
  * リリース処理を段階化し、バージョンタグの不一致を検出できるようにしました。
  * 通常版とプレリリース版を適切な配布チャンネルへ公開し、出所情報も付与します。
  * 公開前に成果物を確認し、より安全な設定で公開します。

* **セキュリティ・保守**
  * 継続的インテグレーションの権限を読み取り中心に見直し、認証情報の保存を無効化しました。
  * ビルドおよび検証に使用するアクションを更新しました。

* **パッケージ情報**
  * パッケージのリポジトリ情報と、必要なネイティブ依存関係のインストール設定を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
